### PR TITLE
swarmctl: require explicit --dataplane-mode flag

### DIFF
--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -87,9 +87,12 @@ func init() {
 		panic(err)
 	}
 
-	// --dataplane-mode flag
-	manifestGenerateCmd.PersistentFlags().String("dataplane-mode", "ambient", "Istio dataplane mode: sidecar or ambient.")
+	// --dataplane-mode flag (required, no default)
+	manifestGenerateCmd.PersistentFlags().String("dataplane-mode", "", "Istio dataplane mode: sidecar or ambient (required).")
 	if err := manifestGenerateCmd.RegisterFlagCompletionFunc("dataplane-mode", dataplaneModeCompletion); err != nil {
+		panic(err)
+	}
+	if err := manifestGenerateCmd.MarkPersistentFlagRequired("dataplane-mode"); err != nil {
 		panic(err)
 	}
 
@@ -138,9 +141,12 @@ func init() {
 		panic(err)
 	}
 
-	// --dataplane-mode flag
-	manifestInstallCmd.PersistentFlags().String("dataplane-mode", "ambient", "Istio dataplane mode: sidecar or ambient.")
+	// --dataplane-mode flag (required, no default)
+	manifestInstallCmd.PersistentFlags().String("dataplane-mode", "", "Istio dataplane mode: sidecar or ambient (required).")
 	if err := manifestInstallCmd.RegisterFlagCompletionFunc("dataplane-mode", dataplaneModeCompletion); err != nil {
+		panic(err)
+	}
+	if err := manifestInstallCmd.MarkPersistentFlagRequired("dataplane-mode"); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
## Summary

Make `--dataplane-mode` an explicit, required flag for `swarmctl manifest generate` and `swarmctl manifest install` (and their subcommands). Previously it defaulted to `ambient`, which made the choice between `sidecar` and `ambient` implicit.

## Changes

- Drop the `"ambient"` default value on both `manifestGenerateCmd` and `manifestInstallCmd` persistent `--dataplane-mode` flags.
- Mark the flag as required via `MarkPersistentFlagRequired` on both commands, so cobra enforces it before the `PreRunE` validator runs.
- Update the flag help text to indicate it is required.

## Rationale

The dataplane mode materially changes generated manifests (namespace labels, sidecar-only resources, waypoint usage, etc.). Defaulting silently to `ambient` is easy to miss and can produce surprising output. Forcing the user to specify it makes intent explicit at the CLI.