### PR TITLE
swarmctl: name worker namespaces after --dataplane-mode

### DIFF
--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -280,7 +280,7 @@ func GenerateWorker(cmd *cobra.Command, args []string) error {
 			WaypointName  string
 		}{
 			Replicas:      replicas,
-			Namespace:     fmt.Sprintf("service-%d", i),
+			Namespace:     fmt.Sprintf("%s-%d", dataplaneMode, i),
 			NodeSelector:  nodeSelector,
 			Version:       cmd.Root().Version,
 			ImageTag:      imageTag,
@@ -322,6 +322,9 @@ func GenerateWorkerExample() string {
 
 func GenerateWorkerTelemetry(cmd *cobra.Command, args []string) error {
 
+	// Get the flags
+	dataplaneMode, _ := cmd.Flags().GetString("dataplane-mode")
+
 	// Set the error prefix
 	cmd.SetErrPrefix("\nError:")
 
@@ -353,7 +356,7 @@ func GenerateWorkerTelemetry(cmd *cobra.Command, args []string) error {
 			Namespace string
 		}{
 			OnOff:     args[0],
-			Namespace: fmt.Sprintf("service-%d", i),
+			Namespace: fmt.Sprintf("%s-%d", dataplaneMode, i),
 		}); err != nil {
 			return err
 		}
@@ -688,7 +691,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 				WaypointName  string
 			}{
 				Replicas:      replicas,
-				Namespace:     fmt.Sprintf("service-%d", i),
+				Namespace:     fmt.Sprintf("%s-%d", dataplaneMode, i),
 				NodeSelector:  nodeSelector,
 				Version:       cmd.Root().Version,
 				ImageTag:      imageTag,
@@ -754,6 +757,9 @@ func InstallWorkerExample() string {
 
 func InstallWorkerTelemetry(cmd *cobra.Command, args []string) error {
 
+	// Get the flags
+	dataplaneMode, _ := cmd.Flags().GetString("dataplane-mode")
+
 	// Set the error prefix
 	cmd.SetErrPrefix("\nError:")
 
@@ -799,7 +805,7 @@ func InstallWorkerTelemetry(cmd *cobra.Command, args []string) error {
 				Namespace string
 			}{
 				OnOff:     args[1],
-				Namespace: fmt.Sprintf("service-%d", i),
+				Namespace: fmt.Sprintf("%s-%d", dataplaneMode, i),
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary

Worker namespaces generated by `swarmctl manifest generate worker` and `swarmctl manifest install worker` (and their `telemetry` subcommands) are now named after the `--dataplane-mode` value instead of the hardcoded `service-` prefix:

- `--dataplane-mode sidecar` → `sidecar-1`, `sidecar-2`, …
- `--dataplane-mode ambient` → `ambient-1`, `ambient-2`, …

The informer namespace (`informer`) is unchanged.

## Why

The previous `service-N` naming gave no hint about which Istio dataplane mode the workload was running under, which made it awkward to keep sidecar and ambient deployments side by side in the same cluster or to reason about them in dashboards/logs.

## Changes

- `cmd/swarmctl/pkg/swarmctl/swarmctl.go`: replace the four `fmt.Sprintf("service-%d", i)` call sites with `fmt.Sprintf("%s-%d", dataplaneMode, i)` in `GenerateWorker`, `GenerateWorkerTelemetry`, `InstallWorker`, and `InstallWorkerTelemetry`.
- The two telemetry handlers now also read `--dataplane-mode` from cobra flags so their namespaces line up with the corresponding worker namespaces.

No template or cobra-flag changes were needed: `worker.goyaml` and `telemetry.goyaml` already render `{{ .Namespace }}`, and `--dataplane-mode` is already a required persistent flag on both the generate and install command groups (set in the parent PR).

## Verification

```
$ go build ./... && go vet ./...
$ go run ./cmd/swarmctl m g w 1:2 --dataplane-mode sidecar | grep '^namespace:' | sort -u
namespace: sidecar-1
namespace: sidecar-2

$ go run ./cmd/swarmctl m g w 1:2 --dataplane-mode ambient | grep '^namespace:' | sort -u
namespace: ambient-1
namespace: ambient-2

$ go run ./cmd/swarmctl m g w 1:2
Error: required flag(s) "dataplane-mode" not set
```

## Breaking change

Any caller scripting against the old `service-N` namespace names will need to switch to `sidecar-N` / `ambient-N`.

## Notes for reviewers

- This PR is stacked on top of `require-dataplane-mode` and targets that branch; once that one merges to `main` it can be retargeted/rebased.
- No new automated tests were added; the repo currently has no tests covering namespace name generation.
