### PR TITLE
swarmctl: opt out of sidecar injection in ambient namespaces

### DIFF
--- a/cmd/swarmctl/assets/informer.goyaml
+++ b/cmd/swarmctl/assets/informer.goyaml
@@ -8,6 +8,9 @@ metadata:
     {{- end }}
     {{- if eq .DataplaneMode "ambient" }}
     istio.io/dataplane-mode: ambient
+    {{- if .IstioRevision }}
+    istio-injection: disabled
+    {{- end }}
     {{- else if not .IstioRevision }}
     istio-injection: enabled
     {{- end }}

--- a/cmd/swarmctl/assets/worker.goyaml
+++ b/cmd/swarmctl/assets/worker.goyaml
@@ -8,6 +8,9 @@ metadata:
     {{- end }}
     {{- if eq .DataplaneMode "ambient" }}
     istio.io/dataplane-mode: ambient
+    {{- if .IstioRevision }}
+    istio-injection: disabled
+    {{- end }}
     {{- else if not .IstioRevision }}
     istio-injection: enabled
     {{- end }}


### PR DESCRIPTION
## Summary
When the worker/informer namespace template is rendered with both `--dataplane-mode ambient` and `--istio-revision <rev>`, the namespace gets `istio.io/rev=<rev>`, which causes the revisioned sidecar mutating webhook to inject a sidecar in addition to the ambient enrollment. Result: pods come up as 2/2 (sidecar + ambient), which is not the intent.

## Fix
In the ambient branch of the namespace label block (`worker.goyaml`, `informer.goyaml`), also emit `istio-injection: disabled` when a revision is set. Per the [Istio sidecar injection docs](https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy):

> If either label (`istio-injection` or `sidecar.istio.io/inject`) is disabled, the pod is not injected.

This rule takes precedence over the rev-based injection rule, so the sidecar webhook skips the namespace while `istio.io/rev` is still honored for revision-scoped ambient resources (waypoints, gateways, policies).

## Rendered label combinations

| mode    | rev   | namespace labels                                                                |
|---------|-------|---------------------------------------------------------------------------------|
| ambient | set   | `istio.io/rev`, `istio.io/dataplane-mode: ambient`, `istio-injection: disabled` |
| ambient | unset | `istio.io/dataplane-mode: ambient`                                              |
| sidecar | set   | `istio.io/rev`                                                                  |
| sidecar | unset | `istio-injection: enabled`                                                      |
