### PR TITLE
swarmctl: drop cluster segment from workload namespace names

### DIFF
--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -87,15 +87,6 @@ func init() {
 		panic(err)
 	}
 
-	// --cluster flag (required for generate; install derives it from the context name)
-	manifestGenerateCmd.PersistentFlags().String("cluster", "", "Short cluster name used in resource names (e.g. 'pasta-1', 'pizza-2'). Required for generate.")
-	if err := manifestGenerateCmd.RegisterFlagCompletionFunc("cluster", clusterCompletion); err != nil {
-		panic(err)
-	}
-	if err := manifestGenerateCmd.MarkPersistentFlagRequired("cluster"); err != nil {
-		panic(err)
-	}
-
 	// --dataplane-mode flag (required, no default)
 	manifestGenerateCmd.PersistentFlags().String("dataplane-mode", "", "Istio dataplane mode: sidecar or ambient (required).")
 	if err := manifestGenerateCmd.RegisterFlagCompletionFunc("dataplane-mode", dataplaneModeCompletion); err != nil {
@@ -426,20 +417,6 @@ func clusterDomainIsValid() bool {
 }
 
 //-----------------------------------------------------------------------------
-// cluster
-//-----------------------------------------------------------------------------
-
-// clusterCompletion
-func clusterCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"pasta-1", "pizza-2"}, cobra.ShellCompDirectiveNoFileComp
-}
-
-// clusterIsValid
-func clusterIsValid(value string) bool {
-	return value != ""
-}
-
-//-----------------------------------------------------------------------------
 // dataplaneMode
 //-----------------------------------------------------------------------------
 
@@ -524,13 +501,6 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("cluster-domain") {
 		if valid := clusterDomainIsValid(); !valid {
 			return errors.New("invalid cluster-domain")
-		}
-	}
-
-	if cmd.Flags().Changed("cluster") {
-		value, _ := cmd.Flags().GetString("cluster")
-		if !clusterIsValid(value) {
-			return errors.New("invalid cluster (must be non-empty)")
 		}
 	}
 

--- a/cmd/swarmctl/pkg/k8sctx/k8sctx.go
+++ b/cmd/swarmctl/pkg/k8sctx/k8sctx.go
@@ -249,20 +249,6 @@ func Filter(regex string) ([]string, error) {
 }
 
 //-----------------------------------------------------------------------------
-// ShortName returns a short, human-friendly cluster name derived from a
-// kubeconfig context name. A leading "kind-" prefix is stripped so that
-// contexts like "kind-pasta-1" yield "pasta-1". An empty input returns
-// "local".
-//-----------------------------------------------------------------------------
-
-func ShortName(ctxName string) string {
-	if ctxName == "" {
-		return "local"
-	}
-	return strings.TrimPrefix(ctxName, "kind-")
-}
-
-//-----------------------------------------------------------------------------
 // GetClusterDomain reads the cluster domain from the CoreDNS ConfigMap.
 // Falls back to "cluster.local" if unable to read or parse.
 //-----------------------------------------------------------------------------

--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -254,7 +254,6 @@ func GenerateWorker(cmd *cobra.Command, args []string) error {
 	clusterDomain, _ := cmd.Flags().GetString("cluster-domain")
 	dataplaneMode, _ := cmd.Flags().GetString("dataplane-mode")
 	waypointName, _ := cmd.Flags().GetString("waypoint-name")
-	cluster, _ := cmd.Flags().GetString("cluster")
 	ingressMode, _ := cmd.Flags().GetString("ingress-mode")
 
 	// Default cluster domain for generate command (no live cluster)
@@ -294,7 +293,7 @@ func GenerateWorker(cmd *cobra.Command, args []string) error {
 			IngressMode   string
 		}{
 			Replicas:      replicas,
-			Namespace:     util.NamespaceName(dataplaneMode, cluster, i),
+			Namespace:     util.NamespaceName(dataplaneMode, i),
 			NodeSelector:  nodeSelector,
 			Version:       cmd.Root().Version,
 			ImageTag:      imageTag,
@@ -315,28 +314,28 @@ func GenerateWorker(cmd *cobra.Command, args []string) error {
 func GenerateWorkerExample() string {
 	return `
   # Output the generated workers 1 to 1 manifests to stdout
-  # (namespace: sidecar-pasta-1-n1)
-  swarmctl manifest generate worker 1:1 --dataplane-mode sidecar --cluster pasta-1
+  # (namespace: sidecar-n1)
+  swarmctl manifest generate worker 1:1 --dataplane-mode sidecar
 
   # Same using command aliases
-  swarmctl m g w 1:1 --dataplane-mode sidecar --cluster pasta-1
+  swarmctl m g w 1:1 --dataplane-mode sidecar
 
   # Set worker replicas and node selector
-  swarmctl m g w 1:1 --dataplane-mode sidecar --cluster pasta-1 --replicas 3 --node-selector '{key1: value1, key2: value2}'
+  swarmctl m g w 1:1 --dataplane-mode sidecar --replicas 3 --node-selector '{key1: value1, key2: value2}'
 
   # Set worker replicas and Istio revision
-  swarmctl m g w 1:1 --dataplane-mode sidecar --cluster pasta-1 --replicas 3 --istio-revision 1-21-1
+  swarmctl m g w 1:1 --dataplane-mode sidecar --replicas 3 --istio-revision 1-21-1
 
   # Generate the worker manifests for Istio ambient mode
-  # (namespace: ambient-pizza-2-n1)
-  swarmctl m g w 1:1 --dataplane-mode ambient --cluster pizza-2
+  # (namespace: ambient-n1)
+  swarmctl m g w 1:1 --dataplane-mode ambient
 
   # Expose the worker Service via the shared istio-system/istio-nsgw gateway
   # (classic Istio Gateway+VirtualService selecting istio: nsgw).
-  swarmctl m g w 1:1 --dataplane-mode sidecar --cluster pasta-1 --ingress-mode shared
+  swarmctl m g w 1:1 --dataplane-mode sidecar --ingress-mode shared
 
   # Expose the worker Service via a dedicated Gateway API Gateway+HTTPRoute.
-  swarmctl m g w 1:1 --dataplane-mode ambient --cluster pasta-1 --ingress-mode dedicated
+  swarmctl m g w 1:1 --dataplane-mode ambient --ingress-mode dedicated
   `
 }
 
@@ -348,7 +347,6 @@ func GenerateWorkerTelemetry(cmd *cobra.Command, args []string) error {
 
 	// Get the flags
 	dataplaneMode, _ := cmd.Flags().GetString("dataplane-mode")
-	cluster, _ := cmd.Flags().GetString("cluster")
 
 	// Set the error prefix
 	cmd.SetErrPrefix("\nError:")
@@ -381,7 +379,7 @@ func GenerateWorkerTelemetry(cmd *cobra.Command, args []string) error {
 			Namespace string
 		}{
 			OnOff:     args[0],
-			Namespace: util.NamespaceName(dataplaneMode, cluster, i),
+			Namespace: util.NamespaceName(dataplaneMode, i),
 		}); err != nil {
 			return err
 		}
@@ -695,9 +693,6 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 		// Print the context
 		fmt.Printf("\n%s\n\n", name)
 
-		// Derive cluster name from the context (e.g. kind-pasta-1 -> pasta-1)
-		cluster := k8sctx.ShortName(name)
-
 		// Determine cluster domain: flag override or auto-detect from CoreDNS
 		clusterDomain := clusterDomainFlag
 		if clusterDomain == "" {
@@ -730,7 +725,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 				IngressMode   string
 			}{
 				Replicas:      replicas,
-				Namespace:     util.NamespaceName(dataplaneMode, cluster, i),
+				Namespace:     util.NamespaceName(dataplaneMode, i),
 				NodeSelector:  nodeSelector,
 				Version:       cmd.Root().Version,
 				ImageTag:      imageTag,
@@ -760,7 +755,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 func InstallWorkerExample() string {
 	return `
   # Install the workers 1 to 1 to the current context
-  # (namespaces follow <mode>-<cluster>-n<index>, e.g. sidecar-pasta-1-n1)
+  # (namespaces follow <mode>-n<index>, e.g. sidecar-n1)
   swarmctl manifest install worker 1:1 --dataplane-mode sidecar
 
   # Same using command aliases
@@ -772,8 +767,7 @@ func InstallWorkerExample() string {
   # Same using a short command chain with aliases
   swarmctl w 1:1 --dataplane-mode sidecar
 
-  # Install the workers 1 to 1 to a specific context (cluster derived from the
-  # context name with any leading 'kind-' stripped, e.g. kind-pasta-1 -> pasta-1)
+  # Install the workers 1 to 1 to a specific context
   swarmctl w 1:1 --dataplane-mode sidecar --context kind-pasta-1
 
   # Install the workers 1 to 1 to all contexts that match a regex
@@ -835,9 +829,6 @@ func InstallWorkerTelemetry(cmd *cobra.Command, args []string) error {
 		// Print the context
 		fmt.Printf("\n%s\n\n", name)
 
-		// Derive cluster name from the context (e.g. kind-pasta-1 -> pasta-1)
-		cluster := k8sctx.ShortName(name)
-
 		// Loop through all CRDs
 		for _, doc := range util.SplitYAML(bytes.NewBuffer(crds)) {
 			if err := context.ApplyYaml(doc); err != nil {
@@ -856,7 +847,7 @@ func InstallWorkerTelemetry(cmd *cobra.Command, args []string) error {
 				Namespace string
 			}{
 				OnOff:     args[1],
-				Namespace: util.NamespaceName(dataplaneMode, cluster, i),
+				Namespace: util.NamespaceName(dataplaneMode, i),
 			})
 			if err != nil {
 				return err

--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -293,7 +293,7 @@ func GenerateWorker(cmd *cobra.Command, args []string) error {
 			IngressMode   string
 		}{
 			Replicas:      replicas,
-			Namespace:     util.NamespaceName(dataplaneMode, i),
+			Namespace:     fmt.Sprintf("%s-n%d", dataplaneMode, i),
 			NodeSelector:  nodeSelector,
 			Version:       cmd.Root().Version,
 			ImageTag:      imageTag,
@@ -379,7 +379,7 @@ func GenerateWorkerTelemetry(cmd *cobra.Command, args []string) error {
 			Namespace string
 		}{
 			OnOff:     args[0],
-			Namespace: util.NamespaceName(dataplaneMode, i),
+			Namespace: fmt.Sprintf("%s-n%d", dataplaneMode, i),
 		}); err != nil {
 			return err
 		}
@@ -725,7 +725,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 				IngressMode   string
 			}{
 				Replicas:      replicas,
-				Namespace:     util.NamespaceName(dataplaneMode, i),
+				Namespace:     fmt.Sprintf("%s-n%d", dataplaneMode, i),
 				NodeSelector:  nodeSelector,
 				Version:       cmd.Root().Version,
 				ImageTag:      imageTag,
@@ -847,7 +847,7 @@ func InstallWorkerTelemetry(cmd *cobra.Command, args []string) error {
 				Namespace string
 			}{
 				OnOff:     args[1],
-				Namespace: util.NamespaceName(dataplaneMode, i),
+				Namespace: fmt.Sprintf("%s-n%d", dataplaneMode, i),
 			})
 			if err != nil {
 				return err

--- a/cmd/swarmctl/pkg/util/util.go
+++ b/cmd/swarmctl/pkg/util/util.go
@@ -148,20 +148,20 @@ func ParseRange(arg string) (int, int, error) {
 }
 
 //-----------------------------------------------------------------------------
-// NamespaceName returns the per-cluster, per-index workload namespace name.
+// NamespaceName returns the per-index workload namespace name.
 //
 // The convention is:
 //
-//	<mode>-<cluster>-n<index>
+//	<mode>-n<index>
 //
 // Examples:
 //
-//	NamespaceName("sidecar", "pasta-1", 1) -> "sidecar-pasta-1-n1"
-//	NamespaceName("ambient", "pizza-2", 3) -> "ambient-pizza-2-n3"
+//	NamespaceName("sidecar", 1) -> "sidecar-n1"
+//	NamespaceName("ambient", 3) -> "ambient-n3"
 //-----------------------------------------------------------------------------
 
-func NamespaceName(mode, cluster string, index int) string {
-	return fmt.Sprintf("%s-%s-n%d", mode, cluster, index)
+func NamespaceName(mode string, index int) string {
+	return fmt.Sprintf("%s-n%d", mode, index)
 }
 
 //-----------------------------------------------------------------------------

--- a/cmd/swarmctl/pkg/util/util.go
+++ b/cmd/swarmctl/pkg/util/util.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"embed"
 	"errors"
-	"fmt"
 	"html/template"
 	"os"
 	"path/filepath"
@@ -145,23 +144,6 @@ func ParseRange(arg string) (int, int, error) {
 
 	// Return
 	return start, end, nil
-}
-
-//-----------------------------------------------------------------------------
-// NamespaceName returns the per-index workload namespace name.
-//
-// The convention is:
-//
-//	<mode>-n<index>
-//
-// Examples:
-//
-//	NamespaceName("sidecar", 1) -> "sidecar-n1"
-//	NamespaceName("ambient", 3) -> "ambient-n3"
-//-----------------------------------------------------------------------------
-
-func NamespaceName(mode string, index int) string {
-	return fmt.Sprintf("%s-n%d", mode, index)
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`util.NamespaceName` now returns `<mode>-n<index>` (e.g. `sidecar-n1`, `ambient-n2`) instead of `<mode>-<cluster>-n<index>`.

## Why

Istio multicluster endpoint merging keys on the `<service>.<namespace>` tuple — endpoints with the same Service in the same Namespace across clusters are treated as one logical service, and the cluster identity is carried by the `topology.istio.io/cluster` label. Baking the cluster name into the namespace (`sidecar-pasta-1-n1`) made every namespace cluster-local by construction and broke cross-cluster topology / locality failover for swarmctl-deployed workloads.

## Changes

- `cmd/swarmctl/pkg/util/util.go` — `NamespaceName(mode string, index int)`; doc updated.
- `cmd/swarmctl/pkg/swarmctl/swarmctl.go` — drop `cluster` plumbing in `GenerateWorker`, `GenerateWorkerTelemetry`, `InstallWorker`, `InstallWorkerTelemetry`; refresh examples; remove the per-context `k8sctx.ShortName(name)` derivation.
- `cmd/swarmctl/cmd/cmd.go` — remove `--cluster` flag (was required on `manifest generate`), its completion, `MarkPersistentFlagRequired`, and the `validateFlags` branch.
- `cmd/swarmctl/pkg/k8sctx/k8sctx.go` — remove now-unused `ShortName` helper.

## What did NOT change

- `--cluster-domain` (Kubernetes DNS suffix, e.g. `cluster.local`) is unrelated and stays.
- `--ingress-mode` and the rest of the surface stay as-is.
- The waypoint `Gateway` and TLS `Certificate` resources still derive their names from `{{ .Namespace }}`; with shared namespace names the `worker-{{ .Namespace }}` Secret is now identical across clusters and (combined with the existing kubernetes-replicator annotation) will produce the same Secret in `istio-system` on every cluster — flagging this for follow-up if cross-cluster cert isolation matters.

## Verification

- `go build ./... && go vet ./...` clean.
- `swarmctl m g w 1:2 --dataplane-mode sidecar` → namespaces `sidecar-n1`, `sidecar-n2`.
- `swarmctl m g w 1:2 --dataplane-mode ambient` → namespaces `ambient-n1`, `ambient-n2`.
- `swarmctl m g i --dataplane-mode sidecar` → namespace `informer` (unchanged).

## Breaking change

- `--cluster` is removed; any caller still passing it must drop it.
- Generated/installed namespace names change. Operators need to delete the old per-cluster namespaces (e.g. `sidecar-pasta-1-n1`) before/after rolling out.
