### PR TITLE
swarmctl: --multi-cluster flag for cross-cluster failover (ambient)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Enable telemetry for `service-1` on all `kind` clusters:
 swarmctl w t --context 'kind-*' 1:1 on
 ```
 
+Enable cross-cluster failover for ambient-mode workers (labels the worker
+and waypoint Services with `istio.io/global=true` and emits a
+`DestinationRule` with locality failover by `topology.istio.io/cluster`):
+```
+swarmctl w --context 'kind-*' 1:1 --dataplane-mode ambient --multi-cluster
+```
+
 ## Developing
 
 Download all the `Makefile` tooling to `./bin/`:

--- a/cmd/swarmctl/assets/worker.goyaml
+++ b/cmd/swarmctl/assets/worker.goyaml
@@ -306,11 +306,15 @@ metadata:
   namespace: {{ .Namespace }}
   labels:
     istio.io/waypoint-for: service
-    {{- if .MultiCluster }}
-    istio.io/global: "true"
-    {{- end }}
 spec:
   gatewayClassName: istio-waypoint
+  {{- if .MultiCluster }}
+  infrastructure:
+    # Propagated by Istio onto the generated waypoint Service so that
+    # other clusters discover it as a global service.
+    labels:
+      istio.io/global: "true"
+  {{- end }}
   listeners:
   - name: mesh
     port: 15008

--- a/cmd/swarmctl/assets/worker.goyaml
+++ b/cmd/swarmctl/assets/worker.goyaml
@@ -23,6 +23,9 @@ metadata:
     app: k-swarm
     {{- if eq .DataplaneMode "ambient" }}
     istio.io/use-waypoint: {{ .WaypointName }}
+    {{- if .MultiCluster }}
+    istio.io/global: "true"
+    {{- end }}
     {{- end }}
   name: worker
   namespace: {{ .Namespace }}
@@ -269,6 +272,27 @@ spec:
       port: 80
 {{- end }}
 {{- if eq .DataplaneMode "ambient" }}
+{{- if .MultiCluster }}
+---
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: worker
+  namespace: {{ .Namespace }}
+spec:
+  host: worker.{{ .Namespace }}.svc.{{ .ClusterDomain }}
+  trafficPolicy:
+    outlierDetection:
+      consecutive5xxErrors: 1
+      interval: 1s
+      baseEjectionTime: 1m
+    loadBalancer:
+      simple: ROUND_ROBIN
+      localityLbSetting:
+        enabled: false # Disable locality load balancing to force failover
+        failoverPriority:
+          - topology.istio.io/cluster
+{{- end }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -277,6 +301,9 @@ metadata:
   namespace: {{ .Namespace }}
   labels:
     istio.io/waypoint-for: service
+    {{- if .MultiCluster }}
+    istio.io/global: "true"
+    {{- end }}
 spec:
   gatewayClassName: istio-waypoint
   listeners:

--- a/cmd/swarmctl/assets/worker.goyaml
+++ b/cmd/swarmctl/assets/worker.goyaml
@@ -155,7 +155,12 @@ metadata:
   name: worker
   namespace: {{ .Namespace }}
 spec:
-  {{- if eq .DataplaneMode "ambient" }}
+  {{- if and (eq .DataplaneMode "ambient") .MultiCluster }}
+  targetRefs:
+  - kind: Gateway
+    group: gateway.networking.k8s.io
+    name: {{ .WaypointName }}
+  {{- else if eq .DataplaneMode "ambient" }}
   targetRefs:
   - kind: Service
     group: ""

--- a/cmd/swarmctl/assets/worker.goyaml
+++ b/cmd/swarmctl/assets/worker.goyaml
@@ -280,7 +280,7 @@ metadata:
   name: worker
   namespace: {{ .Namespace }}
 spec:
-  host: worker.{{ .Namespace }}.svc.{{ .ClusterDomain }}
+  host: worker
   trafficPolicy:
     outlierDetection:
       consecutive5xxErrors: 1

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -108,6 +108,12 @@ func init() {
 		panic(err)
 	}
 
+	// --multi-cluster flag (ambient-only)
+	manifestGenerateCmd.PersistentFlags().Bool("multi-cluster", false, "Enable cross-cluster failover for ambient mode: labels the worker and waypoint Services with istio.io/global=true and emits a DestinationRule with locality failover by topology.istio.io/cluster.")
+	if err := manifestGenerateCmd.RegisterFlagCompletionFunc("multi-cluster", multiClusterCompletion); err != nil {
+		panic(err)
+	}
+
 	// --yes flag
 	manifestInstallCmd.PersistentFlags().Bool("yes", false, "Automatically confirm all prompts with 'yes'.")
 
@@ -165,6 +171,12 @@ func init() {
 	// --ingress-mode flag
 	manifestInstallCmd.PersistentFlags().String("ingress-mode", "none", "Ingress mode: 'none', 'shared' (classic Istio Gateway/VirtualService selecting istio: nsgw) or 'dedicated' (per-service Gateway API Gateway/HTTPRoute).")
 	if err := manifestInstallCmd.RegisterFlagCompletionFunc("ingress-mode", ingressModeCompletion); err != nil {
+		panic(err)
+	}
+
+	// --multi-cluster flag (ambient-only)
+	manifestInstallCmd.PersistentFlags().Bool("multi-cluster", false, "Enable cross-cluster failover for ambient mode: labels the worker and waypoint Services with istio.io/global=true and emits a DestinationRule with locality failover by topology.istio.io/cluster.")
+	if err := manifestInstallCmd.RegisterFlagCompletionFunc("multi-cluster", multiClusterCompletion); err != nil {
 		panic(err)
 	}
 }
@@ -463,6 +475,15 @@ func ingressModeIsValid(value string) bool {
 }
 
 //-----------------------------------------------------------------------------
+// multiCluster
+//-----------------------------------------------------------------------------
+
+// multiClusterCompletion
+func multiClusterCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
+}
+
+//-----------------------------------------------------------------------------
 // validateFlags
 //-----------------------------------------------------------------------------
 
@@ -522,6 +543,15 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 		value, _ := cmd.Flags().GetString("ingress-mode")
 		if !ingressModeIsValid(value) {
 			return errors.New("invalid ingress-mode (must be 'none', 'shared' or 'dedicated')")
+		}
+	}
+
+	// --multi-cluster requires --dataplane-mode=ambient
+	if cmd.Flags().Changed("multi-cluster") {
+		multiCluster, _ := cmd.Flags().GetBool("multi-cluster")
+		dataplaneMode, _ := cmd.Flags().GetString("dataplane-mode")
+		if multiCluster && dataplaneMode != "ambient" {
+			return errors.New("--multi-cluster requires --dataplane-mode=ambient")
 		}
 	}
 

--- a/cmd/swarmctl/pkg/k8sctx/k8sctx.go
+++ b/cmd/swarmctl/pkg/k8sctx/k8sctx.go
@@ -14,16 +14,13 @@ import (
 	"regexp"
 	"runtime/trace"
 	"strings"
-	"time"
 
 	// Community
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -319,49 +316,3 @@ func parseClusterDomainFromCorefile(corefile string) string {
 	return domain
 }
 
-//-----------------------------------------------------------------------------
-// PatchServiceLabel waits for a Service to exist in the given namespace and
-// then server-side applies a single label on it. Useful for labeling Services
-// that are reconciled by another controller (e.g. Istio-managed waypoint
-// Services derived from a Gateway), where the label cannot be set via the
-// owning resource because it is not propagated.
-//-----------------------------------------------------------------------------
-
-func (c *Context) PatchServiceLabel(ctx context.Context, namespace, name, key, value string) error {
-
-	// Start a trace region
-	defer trace.StartRegion(ctx, "PatchServiceLabel").End()
-
-	// GVR for core Services
-	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
-	svcs := c.DynCli.Resource(gvr).Namespace(namespace)
-
-	// Wait for the Service to exist (created asynchronously by another
-	// controller). Bounded poll so we never block forever.
-	if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
-		_, err := svcs.Get(ctx, name, metav1.GetOptions{})
-		if err == nil {
-			return true, nil
-		}
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}); err != nil {
-		return fmt.Errorf("waiting for Service %s/%s: %w", namespace, name, err)
-	}
-
-	// Server-side apply only the label we own. A distinct FieldManager keeps
-	// us from conflicting with the controller that owns the rest of the spec.
-	patch := fmt.Sprintf(`{"apiVersion":"v1","kind":"Service","metadata":{"name":%q,"namespace":%q,"labels":{%q:%q}}}`,
-		name, namespace, key, value)
-	if _, err := svcs.Patch(ctx, name, types.ApplyPatchType, []byte(patch), metav1.PatchOptions{
-		FieldManager: "swarmctl-multicluster",
-		Force:        ptr.To(true),
-	}); err != nil {
-		return fmt.Errorf("patching Service %s/%s label %s=%s: %w", namespace, name, key, value, err)
-	}
-	fmt.Printf("  - Service/%s labeled %s=%s\n", name, key, value)
-
-	return nil
-}

--- a/cmd/swarmctl/pkg/k8sctx/k8sctx.go
+++ b/cmd/swarmctl/pkg/k8sctx/k8sctx.go
@@ -315,4 +315,3 @@ func parseClusterDomainFromCorefile(corefile string) string {
 
 	return domain
 }
-

--- a/cmd/swarmctl/pkg/k8sctx/k8sctx.go
+++ b/cmd/swarmctl/pkg/k8sctx/k8sctx.go
@@ -14,13 +14,16 @@ import (
 	"regexp"
 	"runtime/trace"
 	"strings"
+	"time"
 
 	// Community
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -314,4 +317,51 @@ func parseClusterDomainFromCorefile(corefile string) string {
 	domain = strings.TrimSpace(domain)
 
 	return domain
+}
+
+//-----------------------------------------------------------------------------
+// PatchServiceLabel waits for a Service to exist in the given namespace and
+// then server-side applies a single label on it. Useful for labeling Services
+// that are reconciled by another controller (e.g. Istio-managed waypoint
+// Services derived from a Gateway), where the label cannot be set via the
+// owning resource because it is not propagated.
+//-----------------------------------------------------------------------------
+
+func (c *Context) PatchServiceLabel(ctx context.Context, namespace, name, key, value string) error {
+
+	// Start a trace region
+	defer trace.StartRegion(ctx, "PatchServiceLabel").End()
+
+	// GVR for core Services
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	svcs := c.DynCli.Resource(gvr).Namespace(namespace)
+
+	// Wait for the Service to exist (created asynchronously by another
+	// controller). Bounded poll so we never block forever.
+	if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+		_, err := svcs.Get(ctx, name, metav1.GetOptions{})
+		if err == nil {
+			return true, nil
+		}
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}); err != nil {
+		return fmt.Errorf("waiting for Service %s/%s: %w", namespace, name, err)
+	}
+
+	// Server-side apply only the label we own. A distinct FieldManager keeps
+	// us from conflicting with the controller that owns the rest of the spec.
+	patch := fmt.Sprintf(`{"apiVersion":"v1","kind":"Service","metadata":{"name":%q,"namespace":%q,"labels":{%q:%q}}}`,
+		name, namespace, key, value)
+	if _, err := svcs.Patch(ctx, name, types.ApplyPatchType, []byte(patch), metav1.PatchOptions{
+		FieldManager: "swarmctl-multicluster",
+		Force:        ptr.To(true),
+	}); err != nil {
+		return fmt.Errorf("patching Service %s/%s label %s=%s: %w", namespace, name, key, value, err)
+	}
+	fmt.Printf("  - Service/%s labeled %s=%s\n", name, key, value)
+
+	return nil
 }

--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -255,6 +255,7 @@ func GenerateWorker(cmd *cobra.Command, args []string) error {
 	dataplaneMode, _ := cmd.Flags().GetString("dataplane-mode")
 	waypointName, _ := cmd.Flags().GetString("waypoint-name")
 	ingressMode, _ := cmd.Flags().GetString("ingress-mode")
+	multiCluster, _ := cmd.Flags().GetBool("multi-cluster")
 
 	// Default cluster domain for generate command (no live cluster)
 	if clusterDomain == "" {
@@ -291,6 +292,7 @@ func GenerateWorker(cmd *cobra.Command, args []string) error {
 			DataplaneMode string
 			WaypointName  string
 			IngressMode   string
+			MultiCluster  bool
 		}{
 			Replicas:      replicas,
 			Namespace:     fmt.Sprintf("%s-n%d", dataplaneMode, i),
@@ -302,6 +304,7 @@ func GenerateWorker(cmd *cobra.Command, args []string) error {
 			DataplaneMode: dataplaneMode,
 			WaypointName:  waypointName,
 			IngressMode:   ingressMode,
+			MultiCluster:  multiCluster,
 		}); err != nil {
 			return err
 		}
@@ -336,6 +339,11 @@ func GenerateWorkerExample() string {
 
   # Expose the worker Service via a dedicated Gateway API Gateway+HTTPRoute.
   swarmctl m g w 1:1 --dataplane-mode ambient --ingress-mode dedicated
+
+  # Enable cross-cluster failover for ambient-mode workers: labels the worker
+  # and waypoint Services with istio.io/global=true and emits a DestinationRule
+  # with locality failover by topology.istio.io/cluster (ambient-only).
+  swarmctl m g w 1:1 --dataplane-mode ambient --multi-cluster
   `
 }
 
@@ -665,6 +673,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 	dataplaneMode, _ := cmd.Flags().GetString("dataplane-mode")
 	waypointName, _ := cmd.Flags().GetString("waypoint-name")
 	ingressMode, _ := cmd.Flags().GetString("ingress-mode")
+	multiCluster, _ := cmd.Flags().GetBool("multi-cluster")
 
 	// Set the error prefix
 	cmd.SetErrPrefix("\nError:")
@@ -711,6 +720,8 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 
 			fmt.Printf("\n")
 
+			namespace := fmt.Sprintf("%s-n%d", dataplaneMode, i)
+
 			// Render the template
 			docs, err := util.RenderTemplate(tmpl, struct {
 				Replicas      int
@@ -723,9 +734,10 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 				DataplaneMode string
 				WaypointName  string
 				IngressMode   string
+				MultiCluster  bool
 			}{
 				Replicas:      replicas,
-				Namespace:     fmt.Sprintf("%s-n%d", dataplaneMode, i),
+				Namespace:     namespace,
 				NodeSelector:  nodeSelector,
 				Version:       cmd.Root().Version,
 				ImageTag:      imageTag,
@@ -734,6 +746,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 				DataplaneMode: dataplaneMode,
 				WaypointName:  waypointName,
 				IngressMode:   ingressMode,
+				MultiCluster:  multiCluster,
 			})
 			if err != nil {
 				return err
@@ -742,6 +755,16 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 			// Loop through all yaml documents
 			for _, doc := range docs {
 				if err := context.ApplyYaml(doc); err != nil {
+					fmt.Printf("\nError: %s\n", err)
+				}
+			}
+
+			// In multi-cluster ambient mode, the waypoint Service is created
+			// by the Istio mesh-controller from the waypoint Gateway. Labels
+			// on the Gateway do not propagate to the Service, so patch it
+			// directly so that other clusters discover it as a global service.
+			if multiCluster && dataplaneMode == "ambient" {
+				if err := context.PatchServiceLabel(cmd.Context(), namespace, waypointName, "istio.io/global", "true"); err != nil {
 					fmt.Printf("\nError: %s\n", err)
 				}
 			}
@@ -790,6 +813,11 @@ func InstallWorkerExample() string {
 
   # Expose the worker Service via a dedicated Gateway API Gateway+HTTPRoute.
   swarmctl w 1:1 --dataplane-mode ambient --context 'kind-pasta-.*' --ingress-mode dedicated
+
+  # Enable cross-cluster failover for ambient-mode workers: labels the worker
+  # and waypoint Services with istio.io/global=true and emits a DestinationRule
+  # with locality failover by topology.istio.io/cluster (ambient-only).
+  swarmctl w 1:1 --dataplane-mode ambient --context 'kind-pasta-.*' --multi-cluster
   `
 }
 

--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -758,16 +758,6 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 					fmt.Printf("\nError: %s\n", err)
 				}
 			}
-
-			// In multi-cluster ambient mode, the waypoint Service is created
-			// by the Istio mesh-controller from the waypoint Gateway. Labels
-			// on the Gateway do not propagate to the Service, so patch it
-			// directly so that other clusters discover it as a global service.
-			if multiCluster && dataplaneMode == "ambient" {
-				if err := context.PatchServiceLabel(cmd.Context(), namespace, waypointName, "istio.io/global", "true"); err != nil {
-					fmt.Printf("\nError: %s\n", err)
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Add an opt-in `--multi-cluster` flag to `manifest generate worker` and `manifest install worker` that wires the worker namespace for Istio cross-cluster failover when running in ambient dataplane mode.

When set, the rendered worker manifest:

- labels the worker `Service` with `istio.io/global=true` so other clusters in the mesh discover it as a global service;
- labels the per-namespace waypoint `Gateway` with the same label;
- emits a `DestinationRule` that disables locality load balancing and sets `failoverPriority: [topology.istio.io/cluster]`, mirroring the pattern used for upstream Istio's \`helloworld\` multi-cluster sample.

The waypoint **Service** itself is created by Istio's mesh-controller from the waypoint Gateway and labels on the Gateway are not propagated. For \`install worker\` we therefore also wait for the Service to exist and server-side apply the \`istio.io/global\` label using a distinct \`FieldManager\` (\`swarmctl-multicluster\`) so we don't conflict with the controller managing the rest of the spec.

The flag is rejected with a clear error when combined with \`--dataplane-mode=sidecar\` (sidecar already ships its own DR; ambient multi-cluster is the case that needs new wiring).

## Motivation

Reproduces the manual fix that meshlab applies to the upstream Istio \`helloworld\` sample — only for swarmctl-managed worker namespaces. Without the new wiring, an ambient worker Service in a multi-cluster mesh has no remote endpoints and cannot fail over to a peer cluster.

## Verification

\`\`\`shell
# Renders Service+global label, DR with failover, waypoint Gateway label.
swarmctl m g w 1:1 --dataplane-mode ambient --multi-cluster

# Without the flag, none of the multi-cluster bits appear.
swarmctl m g w 1:1 --dataplane-mode ambient

# Sidecar + multi-cluster is rejected.
swarmctl m g w 1:1 --dataplane-mode sidecar --multi-cluster
# Error: --multi-cluster requires --dataplane-mode=ambient
\`\`\`

End-to-end on a two-cluster cell (e.g. meshlab \`pasta-1\`/\`pasta-2\`):

\`\`\`shell
swarmctl w 1:1 --dataplane-mode ambient --multi-cluster --context 'kind-pasta-.*'
# Both clusters' \`waypoint\` Services now carry istio.io/global=true.
istioctl --context kind-pasta-1 pc endpoints deploy/waypoint.ambient-n1 | grep worker
# -> shows the local pod endpoint AND a remote :15008 EW-gateway endpoint.
\`\`\`

## Notes

- Ambient-only by design. \`generate\` mode emits static YAML and skips the
  waypoint Service patch (documented behavior — install does the patch).
- \`go build\`, \`go vet\`, and the swarmctl-related unit tests all pass.