### PR TITLE
worker: add --worker-log-responses flag for response body logging

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -134,6 +134,12 @@ func initFlags(fs *pflag.FlagSet) *common.FlagPack {
 		2*time.Second,
 		"The interval at which the worker sends requests.")
 
+	fs.BoolVar(
+		&flags.WorkerLogResponses,
+		"worker-log-responses",
+		false,
+		"If set, log the raw JSON response bodies received from the informer's /services endpoint and from peer workers' /data endpoint.")
+
 	return flags
 }
 

--- a/cmd/swarmctl/assets/worker.goyaml
+++ b/cmd/swarmctl/assets/worker.goyaml
@@ -72,6 +72,9 @@ spec:
         - --informer-url=http://informer.informer
         - --informer-poll-interval=60s
         - --worker-request-interval=2s
+        {{- if .LogResponses }}
+        - --worker-log-responses
+        {{- end }}
         command:
         - /manager
         env:

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -114,6 +114,12 @@ func init() {
 		panic(err)
 	}
 
+	// --worker-log-responses flag (worker-only)
+	manifestGenerateCmd.PersistentFlags().Bool("worker-log-responses", false, "If set, the worker logs the raw JSON response bodies received from the informer's /services endpoint and from peer workers' /data endpoint.")
+	if err := manifestGenerateCmd.RegisterFlagCompletionFunc("worker-log-responses", workerLogResponsesCompletion); err != nil {
+		panic(err)
+	}
+
 	// --yes flag
 	manifestInstallCmd.PersistentFlags().Bool("yes", false, "Automatically confirm all prompts with 'yes'.")
 
@@ -177,6 +183,12 @@ func init() {
 	// --multi-cluster flag (ambient-only)
 	manifestInstallCmd.PersistentFlags().Bool("multi-cluster", false, "Enable cross-cluster failover for ambient mode: labels the worker and waypoint Services with istio.io/global=true and emits a DestinationRule with locality failover by topology.istio.io/cluster.")
 	if err := manifestInstallCmd.RegisterFlagCompletionFunc("multi-cluster", multiClusterCompletion); err != nil {
+		panic(err)
+	}
+
+	// --worker-log-responses flag (worker-only)
+	manifestInstallCmd.PersistentFlags().Bool("worker-log-responses", false, "If set, the worker logs the raw JSON response bodies received from the informer's /services endpoint and from peer workers' /data endpoint.")
+	if err := manifestInstallCmd.RegisterFlagCompletionFunc("worker-log-responses", workerLogResponsesCompletion); err != nil {
 		panic(err)
 	}
 }
@@ -480,6 +492,15 @@ func ingressModeIsValid(value string) bool {
 
 // multiClusterCompletion
 func multiClusterCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
+}
+
+//-----------------------------------------------------------------------------
+// workerLogResponses
+//-----------------------------------------------------------------------------
+
+// workerLogResponsesCompletion
+func workerLogResponsesCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -256,6 +256,7 @@ func GenerateWorker(cmd *cobra.Command, args []string) error {
 	waypointName, _ := cmd.Flags().GetString("waypoint-name")
 	ingressMode, _ := cmd.Flags().GetString("ingress-mode")
 	multiCluster, _ := cmd.Flags().GetBool("multi-cluster")
+	logResponses, _ := cmd.Flags().GetBool("worker-log-responses")
 
 	// Default cluster domain for generate command (no live cluster)
 	if clusterDomain == "" {
@@ -293,6 +294,7 @@ func GenerateWorker(cmd *cobra.Command, args []string) error {
 			WaypointName  string
 			IngressMode   string
 			MultiCluster  bool
+			LogResponses  bool
 		}{
 			Replicas:      replicas,
 			Namespace:     fmt.Sprintf("%s-n%d", dataplaneMode, i),
@@ -305,6 +307,7 @@ func GenerateWorker(cmd *cobra.Command, args []string) error {
 			WaypointName:  waypointName,
 			IngressMode:   ingressMode,
 			MultiCluster:  multiCluster,
+			LogResponses:  logResponses,
 		}); err != nil {
 			return err
 		}
@@ -674,6 +677,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 	waypointName, _ := cmd.Flags().GetString("waypoint-name")
 	ingressMode, _ := cmd.Flags().GetString("ingress-mode")
 	multiCluster, _ := cmd.Flags().GetBool("multi-cluster")
+	logResponses, _ := cmd.Flags().GetBool("worker-log-responses")
 
 	// Set the error prefix
 	cmd.SetErrPrefix("\nError:")
@@ -735,6 +739,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 				WaypointName  string
 				IngressMode   string
 				MultiCluster  bool
+				LogResponses  bool
 			}{
 				Replicas:      replicas,
 				Namespace:     namespace,
@@ -747,6 +752,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 				WaypointName:  waypointName,
 				IngressMode:   ingressMode,
 				MultiCluster:  multiCluster,
+				LogResponses:  logResponses,
 			})
 			if err != nil {
 				return err

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -26,4 +26,5 @@ type FlagPack struct {
 	InformerPollInterval  time.Duration
 	WorkerRequestInterval time.Duration
 	InformerURL           string
+	WorkerLogResponses    bool
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -110,10 +110,23 @@ func client(ctx context.Context, flags *common.FlagPack) {
 			for _, service := range serviceList {
 				time.Sleep(flags.WorkerRequestInterval)
 				log.Info("sending a request", "service", service)
-				_, err := http.Get(fmt.Sprintf("http://%s/data", service))
+				resp, err := http.Get(fmt.Sprintf("http://%s/data", service))
 				if err != nil {
 					log.Error(err, "failed to send request", "service", service)
 					continue
+				}
+				if flags.WorkerLogResponses {
+					body, err := io.ReadAll(resp.Body)
+					if err != nil {
+						log.Error(err, "failed to read response body", "service", service)
+					} else {
+						log.Info("response received", "service", service, "body", string(body))
+					}
+				} else {
+					_, _ = io.Copy(io.Discard, resp.Body)
+				}
+				if err := resp.Body.Close(); err != nil {
+					log.Error(err, "failed to close response body", "service", service)
 				}
 			}
 		}
@@ -135,7 +148,7 @@ func pollServiceList(ctx context.Context, flags *common.FlagPack, serviceList *[
 		select {
 		case <-ticker.C:
 			log.Info("polling service list", "url", flags.InformerURL+"/services")
-			newServices, err := fetchServices(flags.InformerURL + "/services")
+			newServices, err := fetchServices(flags.InformerURL+"/services", flags.WorkerLogResponses)
 			if err != nil {
 				log.Error(err, "failed to fetch services")
 				continue
@@ -152,7 +165,7 @@ func pollServiceList(ctx context.Context, flags *common.FlagPack, serviceList *[
 // fetchServices fetches the services from the informer
 //-----------------------------------------------------------------------------
 
-func fetchServices(url string) ([]string, error) {
+func fetchServices(url string, logBody bool) ([]string, error) {
 
 	// Get the services
 	resp, err := http.Get(url)
@@ -176,6 +189,11 @@ func fetchServices(url string) ([]string, error) {
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	// Optionally log the raw response body
+	if logBody {
+		log.Info("services response", "url", url, "body", string(bodyBytes))
 	}
 
 	// Unmarshal the body


### PR DESCRIPTION
Adds a boolean flag `--worker-log-responses` (default `false`) that, when enabled, logs the raw JSON response bodies received by the worker:

- from peer workers' `/data` endpoint (logged from the worker request loop), and
- from the informer's `/services` endpoint (logged from `fetchServices`).

Useful for inspecting the JSON blobs returned by peers without having to crank up the global zap log level.

Also fixes a pre-existing response-body leak in the worker request loop by always closing the response body (and draining it via `io.Copy(io.Discard, ...)` when not logging) so connections can be reused.

### Verification
- `go build ./...` and `go vet ./...` clean.
- Default rendered manifests are unchanged (template not modified); opt in by adding `--worker-log-responses` to the worker Deployment args.