### PR TITLE
swarmctl: derive CLUSTER_NAME from --context on worker generate/install

### DIFF
--- a/cmd/swarmctl/assets/worker.goyaml
+++ b/cmd/swarmctl/assets/worker.goyaml
@@ -79,7 +79,7 @@ spec:
         - /manager
         env:
         - name: CLUSTER_NAME
-          value: kind-dev
+          value: {{ .ClusterName }}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -101,7 +101,7 @@ func init() {
 		panic(err)
 	}
 
-	// --dataplane-mode flag (required, no default)
+	// --dataplane-mode flag
 	manifestGenerateCmd.PersistentFlags().String("dataplane-mode", "", "Istio dataplane mode: sidecar or ambient (required).")
 	if err := manifestGenerateCmd.RegisterFlagCompletionFunc("dataplane-mode", dataplaneModeCompletion); err != nil {
 		panic(err)
@@ -122,17 +122,11 @@ func init() {
 		panic(err)
 	}
 
-	// --multi-cluster flag (ambient-only)
+	// --multi-cluster flag
 	manifestGenerateCmd.PersistentFlags().Bool("multi-cluster", false, "Enable cross-cluster failover for ambient mode: labels the worker and waypoint Services with istio.io/global=true and emits a DestinationRule with locality failover by topology.istio.io/cluster.")
-	if err := manifestGenerateCmd.RegisterFlagCompletionFunc("multi-cluster", multiClusterCompletion); err != nil {
-		panic(err)
-	}
 
-	// --log-responses flag (worker-only)
+	// --log-responses flag
 	manifestGenerateCmd.PersistentFlags().Bool("log-responses", false, "If set, the worker logs the raw JSON response bodies received from the informer's /services endpoint and from peer workers' /data endpoint.")
-	if err := manifestGenerateCmd.RegisterFlagCompletionFunc("log-responses", logResponsesCompletion); err != nil {
-		panic(err)
-	}
 
 	//------------------------
 	// manifest install flags
@@ -177,7 +171,7 @@ func init() {
 		panic(err)
 	}
 
-	// --dataplane-mode flag (required, no default)
+	// --dataplane-mode flag
 	manifestInstallCmd.PersistentFlags().String("dataplane-mode", "", "Istio dataplane mode: sidecar or ambient (required).")
 	if err := manifestInstallCmd.RegisterFlagCompletionFunc("dataplane-mode", dataplaneModeCompletion); err != nil {
 		panic(err)
@@ -198,17 +192,11 @@ func init() {
 		panic(err)
 	}
 
-	// --multi-cluster flag (ambient-only)
+	// --multi-cluster flag
 	manifestInstallCmd.PersistentFlags().Bool("multi-cluster", false, "Enable cross-cluster failover for ambient mode: labels the worker and waypoint Services with istio.io/global=true and emits a DestinationRule with locality failover by topology.istio.io/cluster.")
-	if err := manifestInstallCmd.RegisterFlagCompletionFunc("multi-cluster", multiClusterCompletion); err != nil {
-		panic(err)
-	}
 
-	// --log-responses flag (worker-only)
+	// --log-responses flag
 	manifestInstallCmd.PersistentFlags().Bool("log-responses", false, "If set, the worker logs the raw JSON response bodies received from the informer's /services endpoint and from peer workers' /data endpoint.")
-	if err := manifestInstallCmd.RegisterFlagCompletionFunc("log-responses", logResponsesCompletion); err != nil {
-		panic(err)
-	}
 }
 
 //-----------------------------------------------------------------------------
@@ -502,24 +490,6 @@ func ingressModeIsValid(value string) bool {
 		return true
 	}
 	return false
-}
-
-//-----------------------------------------------------------------------------
-// multiCluster
-//-----------------------------------------------------------------------------
-
-// multiClusterCompletion
-func multiClusterCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
-}
-
-//-----------------------------------------------------------------------------
-// logResponsesCompletion
-//-----------------------------------------------------------------------------
-
-// logResponsesCompletion
-func logResponsesCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
 }
 
 //-----------------------------------------------------------------------------

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -555,15 +555,6 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// --multi-cluster requires --dataplane-mode=ambient
-	if cmd.Flags().Changed("multi-cluster") {
-		multiCluster, _ := cmd.Flags().GetBool("multi-cluster")
-		dataplaneMode, _ := cmd.Flags().GetString("dataplane-mode")
-		if multiCluster && dataplaneMode != "ambient" {
-			return errors.New("--multi-cluster requires --dataplane-mode=ambient")
-		}
-	}
-
 	// Return
 	return nil
 }

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -132,9 +132,6 @@ func init() {
 	// manifest install flags
 	//------------------------
 
-	// --yes flag
-	manifestInstallCmd.PersistentFlags().Bool("yes", false, "Automatically confirm all prompts with 'yes'.")
-
 	// --context flag
 	manifestInstallCmd.PersistentFlags().String("context", "", "regex to match the context name.")
 	if err := manifestInstallCmd.RegisterFlagCompletionFunc("context", contextCompletion); err != nil {
@@ -191,6 +188,9 @@ func init() {
 	if err := manifestInstallCmd.RegisterFlagCompletionFunc("ingress-mode", ingressModeCompletion); err != nil {
 		panic(err)
 	}
+
+	// --yes flag
+	manifestInstallCmd.PersistentFlags().Bool("yes", false, "Automatically confirm all prompts with 'yes'.")
 
 	// --multi-cluster flag
 	manifestInstallCmd.PersistentFlags().Bool("multi-cluster", false, "Enable cross-cluster failover for ambient mode: labels the worker and waypoint Services with istio.io/global=true and emits a DestinationRule with locality failover by topology.istio.io/cluster.")

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -54,7 +54,11 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&profiling.MemProfileFile, "mem-profile-file", "mem.prof", "file for memory profiling output")
 	rootCmd.PersistentFlags().StringVar(&profiling.TracingFile, "tracing-file", "trace.out", "file for tracing output")
 
-	// manifestDumpCmd flags
+	//---------------------
+	// manifest dump flags
+	//---------------------
+
+	// --stdout flag
 	manifestDumpCmd.Flags().Bool("stdout", false, "Output to stdout")
 
 	//-------------------------
@@ -509,6 +513,11 @@ func multiClusterCompletion(cmd *cobra.Command, args []string, toComplete string
 	return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
 }
 
+// multiClusterIsValid
+func multiClusterIsValid(value string) bool {
+	return value == "true" || value == "false"
+}
+
 //-----------------------------------------------------------------------------
 // logResponsesCompletion
 //-----------------------------------------------------------------------------
@@ -516,6 +525,11 @@ func multiClusterCompletion(cmd *cobra.Command, args []string, toComplete string
 // logResponsesCompletion
 func logResponsesCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
+}
+
+// logResponsesIsValid
+func logResponsesIsValid(value string) bool {
+	return value == "true" || value == "false"
 }
 
 //-----------------------------------------------------------------------------

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -57,6 +57,16 @@ func init() {
 	// manifestDumpCmd flags
 	manifestDumpCmd.Flags().Bool("stdout", false, "Output to stdout")
 
+	//-------------------------
+	// manifest generate flags
+	//-------------------------
+
+	// --context flag
+	manifestGenerateCmd.PersistentFlags().String("context", "", "regex to match the context name.")
+	if err := manifestGenerateCmd.RegisterFlagCompletionFunc("context", contextCompletion); err != nil {
+		panic(err)
+	}
+
 	// --replicas flag
 	manifestGenerateCmd.PersistentFlags().Int("replicas", 1, "Number of replicas to deploy.")
 	if err := manifestGenerateCmd.RegisterFlagCompletionFunc("replicas", replicasCompletion); err != nil {
@@ -120,15 +130,9 @@ func init() {
 		panic(err)
 	}
 
-	// --context flag (worker-only on generate; required so we can derive
-	// the per-cluster CLUSTER_NAME from the matched context name).
-	manifestGenerateWorkerCmd.Flags().String("context", "", "regex to match the context name.")
-	if err := manifestGenerateWorkerCmd.RegisterFlagCompletionFunc("context", contextCompletion); err != nil {
-		panic(err)
-	}
-	if err := manifestGenerateWorkerCmd.MarkFlagRequired("context"); err != nil {
-		panic(err)
-	}
+	//------------------------
+	// manifest install flags
+	//------------------------
 
 	// --yes flag
 	manifestInstallCmd.PersistentFlags().Bool("yes", false, "Automatically confirm all prompts with 'yes'.")

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -513,11 +513,6 @@ func multiClusterCompletion(cmd *cobra.Command, args []string, toComplete string
 	return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
 }
 
-// multiClusterIsValid
-func multiClusterIsValid(value string) bool {
-	return value == "true" || value == "false"
-}
-
 //-----------------------------------------------------------------------------
 // logResponsesCompletion
 //-----------------------------------------------------------------------------
@@ -527,11 +522,6 @@ func logResponsesCompletion(cmd *cobra.Command, args []string, toComplete string
 	return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
 }
 
-// logResponsesIsValid
-func logResponsesIsValid(value string) bool {
-	return value == "true" || value == "false"
-}
-
 //-----------------------------------------------------------------------------
 // validateFlags
 //-----------------------------------------------------------------------------
@@ -539,37 +529,37 @@ func logResponsesIsValid(value string) bool {
 func validateFlags(cmd *cobra.Command, args []string) error {
 
 	if cmd.Flags().Changed("context") {
-		if valid := contextIsValid(); !valid {
+		if !contextIsValid() {
 			return errors.New("invalid context")
 		}
 	}
 
 	if cmd.Flags().Changed("replicas") {
-		if valid := replicasIsValid(); !valid {
+		if !replicasIsValid() {
 			return errors.New("invalid replicas")
 		}
 	}
 
 	if cmd.Flags().Changed("node-selector") {
-		if valid := nodeSelectorIsValid(); !valid {
+		if !nodeSelectorIsValid() {
 			return errors.New("invalid node-selector")
 		}
 	}
 
 	if cmd.Flags().Changed("image-tag") {
-		if valid := imageTagIsValid(); !valid {
+		if !imageTagIsValid() {
 			return errors.New("invalid image-tag")
 		}
 	}
 
 	if cmd.Flags().Changed("istio-revision") {
-		if valid := istioRevisionIsValid(); !valid {
+		if !istioRevisionIsValid() {
 			return errors.New("invalid istio-revision")
 		}
 	}
 
 	if cmd.Flags().Changed("cluster-domain") {
-		if valid := clusterDomainIsValid(); !valid {
+		if !clusterDomainIsValid() {
 			return errors.New("invalid cluster-domain")
 		}
 	}

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -120,6 +120,16 @@ func init() {
 		panic(err)
 	}
 
+	// --context flag (worker-only on generate; required so we can derive
+	// the per-cluster CLUSTER_NAME from the matched context name).
+	manifestGenerateWorkerCmd.Flags().String("context", "", "regex to match the context name.")
+	if err := manifestGenerateWorkerCmd.RegisterFlagCompletionFunc("context", contextCompletion); err != nil {
+		panic(err)
+	}
+	if err := manifestGenerateWorkerCmd.MarkFlagRequired("context"); err != nil {
+		panic(err)
+	}
+
 	// --yes flag
 	manifestInstallCmd.PersistentFlags().Bool("yes", false, "Automatically confirm all prompts with 'yes'.")
 

--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -247,6 +248,7 @@ func GenerateInformerTelemetryExample() string {
 func GenerateWorker(cmd *cobra.Command, args []string) error {
 
 	// Get the flags
+	ctxRegex, _ := cmd.Flags().GetString("context")
 	replicas, _ := cmd.Flags().GetInt("replicas")
 	nodeSelector, _ := cmd.Flags().GetString("node-selector")
 	imageTag, _ := cmd.Flags().GetString("image-tag")
@@ -272,44 +274,62 @@ func GenerateWorker(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Resolve the kube-context regex to a sorted list of matched names. We
+	// only need the names here (no live client) to derive ClusterName.
+	matches, err := k8sctx.Filter(ctxRegex)
+	if err != nil {
+		return err
+	}
+	sort.Strings(matches)
+
 	// Parse the template
 	tmpl, err := util.ParseTemplate(Assets, "worker")
 	if err != nil {
 		return err
 	}
 
-	// Loop from start to end
-	for i := start; i <= end; i++ {
+	// Loop over each matched context
+	for _, ctxName := range matches {
 
-		// Render the template
-		if err := tmpl.Execute(cmd.OutOrStdout(), struct {
-			Replicas      int
-			Namespace     string
-			NodeSelector  string
-			Version       string
-			ImageTag      string
-			IstioRevision string
-			ClusterDomain string
-			DataplaneMode string
-			WaypointName  string
-			IngressMode   string
-			MultiCluster  bool
-			LogResponses  bool
-		}{
-			Replicas:      replicas,
-			Namespace:     fmt.Sprintf("%s-n%d", dataplaneMode, i),
-			NodeSelector:  nodeSelector,
-			Version:       cmd.Root().Version,
-			ImageTag:      imageTag,
-			IstioRevision: istioRevision,
-			ClusterDomain: clusterDomain,
-			DataplaneMode: dataplaneMode,
-			WaypointName:  waypointName,
-			IngressMode:   ingressMode,
-			MultiCluster:  multiCluster,
-			LogResponses:  logResponses,
-		}); err != nil {
-			return err
+		// Derive cluster name by stripping the kind- prefix (no-op for
+		// non-kind contexts).
+		clusterName := strings.TrimPrefix(ctxName, "kind-")
+
+		// Loop from start to end
+		for i := start; i <= end; i++ {
+
+			// Render the template
+			if err := tmpl.Execute(cmd.OutOrStdout(), struct {
+				Replicas      int
+				Namespace     string
+				NodeSelector  string
+				Version       string
+				ImageTag      string
+				IstioRevision string
+				ClusterDomain string
+				ClusterName   string
+				DataplaneMode string
+				WaypointName  string
+				IngressMode   string
+				MultiCluster  bool
+				LogResponses  bool
+			}{
+				Replicas:      replicas,
+				Namespace:     fmt.Sprintf("%s-n%d", dataplaneMode, i),
+				NodeSelector:  nodeSelector,
+				Version:       cmd.Root().Version,
+				ImageTag:      imageTag,
+				IstioRevision: istioRevision,
+				ClusterDomain: clusterDomain,
+				ClusterName:   clusterName,
+				DataplaneMode: dataplaneMode,
+				WaypointName:  waypointName,
+				IngressMode:   ingressMode,
+				MultiCluster:  multiCluster,
+				LogResponses:  logResponses,
+			}); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -320,33 +340,37 @@ func GenerateWorker(cmd *cobra.Command, args []string) error {
 func GenerateWorkerExample() string {
 	return `
   # Output the generated workers 1 to 1 manifests to stdout
-  # (namespace: sidecar-n1)
-  swarmctl manifest generate worker 1:1 --dataplane-mode sidecar
+  # (namespace: sidecar-n1, CLUSTER_NAME derived from --context).
+  swarmctl manifest generate worker 1:1 --dataplane-mode sidecar --context kind-dev
 
   # Same using command aliases
-  swarmctl m g w 1:1 --dataplane-mode sidecar
+  swarmctl m g w 1:1 --dataplane-mode sidecar --context kind-dev
+
+  # Render manifests for every matching context (one rendered set per context,
+  # each with its own CLUSTER_NAME stripped of the kind- prefix).
+  swarmctl m g w 1:1 --dataplane-mode ambient --context 'kind-pasta-.*'
 
   # Set worker replicas and node selector
-  swarmctl m g w 1:1 --dataplane-mode sidecar --replicas 3 --node-selector '{key1: value1, key2: value2}'
+  swarmctl m g w 1:1 --dataplane-mode sidecar --context kind-dev --replicas 3 --node-selector '{key1: value1, key2: value2}'
 
   # Set worker replicas and Istio revision
-  swarmctl m g w 1:1 --dataplane-mode sidecar --replicas 3 --istio-revision 1-21-1
+  swarmctl m g w 1:1 --dataplane-mode sidecar --context kind-dev --replicas 3 --istio-revision 1-21-1
 
   # Generate the worker manifests for Istio ambient mode
   # (namespace: ambient-n1)
-  swarmctl m g w 1:1 --dataplane-mode ambient
+  swarmctl m g w 1:1 --dataplane-mode ambient --context kind-dev
 
   # Expose the worker Service via the shared istio-system/istio-nsgw gateway
   # (classic Istio Gateway+VirtualService selecting istio: nsgw).
-  swarmctl m g w 1:1 --dataplane-mode sidecar --ingress-mode shared
+  swarmctl m g w 1:1 --dataplane-mode sidecar --context kind-dev --ingress-mode shared
 
   # Expose the worker Service via a dedicated Gateway API Gateway+HTTPRoute.
-  swarmctl m g w 1:1 --dataplane-mode ambient --ingress-mode dedicated
+  swarmctl m g w 1:1 --dataplane-mode ambient --context kind-dev --ingress-mode dedicated
 
   # Enable cross-cluster failover for ambient-mode workers: labels the worker
   # and waypoint Services with istio.io/global=true and emits a DestinationRule
   # with locality failover by topology.istio.io/cluster (ambient-only).
-  swarmctl m g w 1:1 --dataplane-mode ambient --multi-cluster
+  swarmctl m g w 1:1 --dataplane-mode ambient --context kind-dev --multi-cluster
   `
 }
 
@@ -712,6 +736,10 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 			clusterDomain = context.GetClusterDomain(cmd.Context())
 		}
 
+		// Derive cluster name by stripping the kind- prefix (no-op for
+		// non-kind contexts).
+		clusterName := strings.TrimPrefix(context.Name, "kind-")
+
 		// Loop through all CRDs
 		for _, doc := range util.SplitYAML(bytes.NewBuffer(crds)) {
 			if err := context.ApplyYaml(doc); err != nil {
@@ -735,6 +763,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 				ImageTag      string
 				IstioRevision string
 				ClusterDomain string
+				ClusterName   string
 				DataplaneMode string
 				WaypointName  string
 				IngressMode   string
@@ -748,6 +777,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 				ImageTag:      imageTag,
 				IstioRevision: istioRevision,
 				ClusterDomain: clusterDomain,
+				ClusterName:   clusterName,
 				DataplaneMode: dataplaneMode,
 				WaypointName:  waypointName,
 				IngressMode:   ingressMode,


### PR DESCRIPTION
## Summary

Replace the hardcoded `kind-dev` value of the `CLUSTER_NAME` env var in [`worker.goyaml`](cmd/swarmctl/assets/worker.goyaml) with `{{ .ClusterName }}`, derived from the matched kube-context name with the leading `kind-` prefix stripped.

## Changes

- `manifest generate worker` now requires `--context` (regex, same semantics as `install`). Generate loops over every matched context and emits one rendered manifest set per context, each with its own `CLUSTER_NAME`.
- `InstallWorker` computes `ClusterName` per context inside its existing loop over `Contexts`.
- Updated `GenerateWorkerExample()` to reflect the new required flag.

## Verification

```
$ swarmctl m g w 1:1 --dataplane-mode ambient
Error: required flag(s) "context" not set

$ swarmctl m g w 1:1 --dataplane-mode ambient --context kind-mnger-1 | grep -A1 CLUSTER_NAME
        - name: CLUSTER_NAME
          value: mnger-1

$ swarmctl m g w 1:1 --dataplane-mode ambient --context 'kind-pasta-.*' | grep -E 'CLUSTER_NAME|value: pasta'
        - name: CLUSTER_NAME
          value: pasta-1
        - name: CLUSTER_NAME
          value: pasta-2
```