### PR TITLE
Split informer/worker templates by dataplane mode

### DIFF
--- a/cmd/swarmctl/assets/informer-ambient.goyaml
+++ b/cmd/swarmctl/assets/informer-ambient.goyaml
@@ -1,0 +1,386 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    {{- if .IstioRevision }}
+    istio.io/rev: {{ .IstioRevision }}
+    {{- end }}
+    istio.io/dataplane-mode: ambient
+    {{- if .IstioRevision }}
+    istio-injection: disabled
+    {{- end }}
+  name: informer
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: k-swarm
+    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: k-swarm
+  name: controller-manager
+  namespace: informer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: k-swarm
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: role
+    app.kubernetes.io/part-of: k-swarm
+  name: leader-election-role
+  namespace: informer
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: k-swarm
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: k-swarm
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: k-swarm
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/part-of: k-swarm
+  name: leader-election-rolebinding
+  namespace: informer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: informer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: k-swarm
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: k-swarm
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: informer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: k-swarm
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: k-swarm
+    control-plane: controller-manager
+  name: controller-manager-metrics-service
+  namespace: informer
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: informer
+  namespace: informer
+  labels:
+    istio.io/use-waypoint: {{ .WaypointName }}
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: informer
+  selector:
+    k-swarm/informer: enabled
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: informer
+  namespace: informer
+spec:
+  replicas: {{ .Replicas }}
+  selector:
+    matchLabels:
+      k-swarm/informer: enabled
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app: informer
+        version: v1
+        k-swarm/informer: enabled
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: k-swarm/informer
+                  operator: In
+                  values:
+                  - enabled
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - args:
+        - --leader-elect=false
+        - --enable-informer=true
+        - --enable-worker=false
+        - --informer-bind-address=:8083
+        command:
+        - /manager
+        image: ghcr.io/h0tbird/k-swarm:{{ if .ImageTag }}{{ .ImageTag }}{{ else }}v{{ .Version }}{{ end }}
+        {{- if .ImageTag}}
+        imagePullPolicy: Always
+        {{- end}}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        - containerPort: 8083
+          name: informer
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      {{- if .NodeSelector}}
+      nodeSelector: {{.NodeSelector}}
+      {{- end}}
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: informer
+  namespace: informer
+spec:
+  targetRefs:
+  - kind: Service
+    group: ""
+    name: informer
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+        methods: ["GET"]
+        paths: ["/services"]
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .WaypointName }}
+  namespace: informer
+  labels:
+    istio.io/waypoint-for: service
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+  - name: mesh
+    port: 15008
+    protocol: HBONE
+{{- if eq .IngressMode "shared" }}
+---
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: informer
+  namespace: informer
+spec:
+  selector:
+    istio: nsgw
+  servers:
+  - hosts:
+    - 'informer.demo.lab'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: informer
+  namespace: informer
+spec:
+  gateways:
+  - informer
+  hosts:
+  - 'informer.demo.lab'
+  http:
+  - route:
+    - destination:
+        host: informer
+        port:
+          number: 80
+      weight: 100
+{{- else if eq .IngressMode "dedicated" }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: informer-ingress
+  namespace: informer
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: http
+    hostname: 'informer.demo.lab'
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: informer
+  namespace: informer
+spec:
+  parentRefs:
+  - name: informer-ingress
+  hostnames:
+  - 'informer.demo.lab'
+  rules:
+  - backendRefs:
+    - name: informer
+      port: 80
+{{- end }}

--- a/cmd/swarmctl/assets/informer-sidecar.goyaml
+++ b/cmd/swarmctl/assets/informer-sidecar.goyaml
@@ -5,13 +5,7 @@ metadata:
   labels:
     {{- if .IstioRevision }}
     istio.io/rev: {{ .IstioRevision }}
-    {{- end }}
-    {{- if eq .DataplaneMode "ambient" }}
-    istio.io/dataplane-mode: ambient
-    {{- if .IstioRevision }}
-    istio-injection: disabled
-    {{- end }}
-    {{- else if not .IstioRevision }}
+    {{- else }}
     istio-injection: enabled
     {{- end }}
   name: informer
@@ -203,10 +197,6 @@ kind: Service
 metadata:
   name: informer
   namespace: informer
-  {{- if eq .DataplaneMode "ambient" }}
-  labels:
-    istio.io/use-waypoint: {{ .WaypointName }}
-  {{- end }}
 spec:
   ports:
   - name: http
@@ -230,12 +220,10 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
-        {{- if ne .DataplaneMode "ambient" }}
         sidecar.istio.io/proxyCPU: 50m
         sidecar.istio.io/proxyCPULimit: 500m
         sidecar.istio.io/proxyMemory: 64Mi
         sidecar.istio.io/proxyMemoryLimit: 512Mi
-        {{- end }}
       labels:
         app: informer
         version: v1
@@ -297,7 +285,6 @@ spec:
         runAsNonRoot: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
-{{- if ne .DataplaneMode "ambient" }}
 ---
 apiVersion: security.istio.io/v1
 kind: PeerAuthentication
@@ -310,7 +297,6 @@ spec:
       k-swarm/informer: enabled
   mtls:
     mode: STRICT
-{{- end }}
 ---
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
@@ -318,38 +304,15 @@ metadata:
   name: informer
   namespace: informer
 spec:
-  {{- if eq .DataplaneMode "ambient" }}
-  targetRefs:
-  - kind: Service
-    group: ""
-    name: informer
-  {{- else }}
   selector:
     matchLabels:
       k-swarm/informer: enabled
-  {{- end }}
   action: ALLOW
   rules:
   - to:
     - operation:
         methods: ["GET"]
         paths: ["/services"]
-{{- if eq .DataplaneMode "ambient" }}
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: {{ .WaypointName }}
-  namespace: informer
-  labels:
-    istio.io/waypoint-for: service
-spec:
-  gatewayClassName: istio-waypoint
-  listeners:
-  - name: mesh
-    port: 15008
-    protocol: HBONE
-{{- end }}
 {{- if eq .IngressMode "shared" }}
 ---
 apiVersion: networking.istio.io/v1

--- a/cmd/swarmctl/assets/worker-ambient.goyaml
+++ b/cmd/swarmctl/assets/worker-ambient.goyaml
@@ -1,0 +1,273 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    {{- if .IstioRevision }}
+    istio.io/rev: {{ .IstioRevision }}
+    {{- end }}
+    istio.io/dataplane-mode: ambient
+    {{- if .IstioRevision }}
+    istio-injection: disabled
+    {{- end }}
+  name: {{ .Namespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: k-swarm
+    istio.io/use-waypoint: {{ .WaypointName }}
+    {{- if .MultiCluster }}
+    istio.io/global: "true"
+    {{- end }}
+  name: worker
+  namespace: {{ .Namespace }}
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: worker
+  selector:
+    k-swarm/worker: enabled
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  namespace: {{ .Namespace }}
+spec:
+  replicas: {{ .Replicas }}
+  selector:
+    matchLabels:
+      k-swarm/worker: enabled
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app: worker
+        version: v1
+        k-swarm/worker: enabled
+    spec:
+      containers:
+      - args:
+        - --leader-elect=false
+        - --enable-informer=false
+        - --enable-worker=true
+        - --worker-bind-address=:8082
+        - --informer-url=http://informer.informer
+        - --informer-poll-interval=60s
+        - --worker-request-interval=2s
+        {{- if .LogResponses }}
+        - --worker-log-responses
+        {{- end }}
+        command:
+        - /manager
+        env:
+        - name: CLUSTER_NAME
+          value: {{ .ClusterName }}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: ghcr.io/h0tbird/k-swarm:{{ if .ImageTag }}{{ .ImageTag }}{{ else }}v{{ .Version }}{{ end }}
+        {{- if .ImageTag}}
+        imagePullPolicy: Always
+        {{- end}}
+        name: manager
+        ports:
+        - containerPort: 8082
+          name: worker
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      {{- if .NodeSelector}}
+      nodeSelector: {{.NodeSelector}}
+      {{- end}}
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 10
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: worker
+  namespace: {{ .Namespace }}
+spec:
+  {{- if .MultiCluster }}
+  targetRefs:
+  - kind: Gateway
+    group: gateway.networking.k8s.io
+    name: {{ .WaypointName }}
+  {{- else }}
+  targetRefs:
+  - kind: Service
+    group: ""
+    name: worker
+  {{- end }}
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+        methods: ["GET"]
+        paths: ["/data"]
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: worker
+  namespace: {{ .Namespace }}
+spec:
+  duration: 24h0m0s
+  renewBefore: 12h0m0s
+  secretName: worker-{{ .Namespace }}
+  dnsNames:
+  - '{{ .Namespace }}.demo.lab'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: ingress-ca
+  revisionHistoryLimit: 2
+  secretTemplate:
+    annotations:
+      replicator.v1.mittwald.de/replicate-to: 'istio-system'
+  privateKey:
+    rotationPolicy: Always
+{{- if eq .IngressMode "shared" }}
+---
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: worker
+  namespace: {{ .Namespace }}
+spec:
+  selector:
+    istio: nsgw
+  servers:
+  - hosts:
+    - '{{ .Namespace }}.demo.lab'
+    port:
+      name: https
+      number: 443
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: worker-{{ .Namespace }}
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: worker
+  namespace: {{ .Namespace }}
+spec:
+  gateways:
+  - worker
+  hosts:
+  - '{{ .Namespace }}.demo.lab'
+  http:
+  - match:
+    - port: 443
+    route:
+    - destination:
+        host: 'worker.{{ .Namespace }}.svc.{{ .ClusterDomain }}'
+        port:
+          number: 80
+      weight: 100
+{{- else if eq .IngressMode "dedicated" }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: worker-ingress
+  namespace: {{ .Namespace }}
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: https
+    hostname: '{{ .Namespace }}.demo.lab'
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - kind: Secret
+        name: worker-{{ .Namespace }}
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: worker
+  namespace: {{ .Namespace }}
+spec:
+  parentRefs:
+  - name: worker-ingress
+  hostnames:
+  - '{{ .Namespace }}.demo.lab'
+  rules:
+  - backendRefs:
+    - name: worker
+      port: 80
+{{- end }}
+{{- if .MultiCluster }}
+---
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: worker
+  namespace: {{ .Namespace }}
+spec:
+  host: worker
+  trafficPolicy:
+    outlierDetection:
+      consecutive5xxErrors: 1
+      interval: 1s
+      baseEjectionTime: 1m
+    loadBalancer:
+      simple: ROUND_ROBIN
+      localityLbSetting:
+        enabled: false # Disable locality load balancing to force failover
+        failoverPriority:
+          - topology.istio.io/cluster
+{{- end }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .WaypointName }}
+  namespace: {{ .Namespace }}
+  labels:
+    istio.io/waypoint-for: service
+spec:
+  gatewayClassName: istio-waypoint
+  {{- if .MultiCluster }}
+  infrastructure:
+    # Propagated by Istio onto the generated waypoint Service so that
+    # other clusters discover it as a global service.
+    labels:
+      istio.io/global: "true"
+  {{- end }}
+  listeners:
+  - name: mesh
+    port: 15008
+    protocol: HBONE

--- a/cmd/swarmctl/assets/worker-sidecar.goyaml
+++ b/cmd/swarmctl/assets/worker-sidecar.goyaml
@@ -5,13 +5,7 @@ metadata:
   labels:
     {{- if .IstioRevision }}
     istio.io/rev: {{ .IstioRevision }}
-    {{- end }}
-    {{- if eq .DataplaneMode "ambient" }}
-    istio.io/dataplane-mode: ambient
-    {{- if .IstioRevision }}
-    istio-injection: disabled
-    {{- end }}
-    {{- else if not .IstioRevision }}
+    {{- else }}
     istio-injection: enabled
     {{- end }}
   name: {{ .Namespace }}
@@ -21,12 +15,6 @@ kind: Service
 metadata:
   labels:
     app: k-swarm
-    {{- if eq .DataplaneMode "ambient" }}
-    istio.io/use-waypoint: {{ .WaypointName }}
-    {{- if .MultiCluster }}
-    istio.io/global: "true"
-    {{- end }}
-    {{- end }}
   name: worker
   namespace: {{ .Namespace }}
 spec:
@@ -52,12 +40,10 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
-        {{- if ne .DataplaneMode "ambient" }}
         sidecar.istio.io/proxyCPU: 50m
         sidecar.istio.io/proxyCPULimit: 500m
         sidecar.istio.io/proxyMemory: 64Mi
         sidecar.istio.io/proxyMemoryLimit: 512Mi
-        {{- end }}
       labels:
         app: worker
         version: v1
@@ -117,7 +103,6 @@ spec:
         runAsNonRoot: true
       serviceAccountName: default
       terminationGracePeriodSeconds: 10
-{{- if ne .DataplaneMode "ambient" }}
 ---
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
@@ -150,7 +135,6 @@ spec:
       k-swarm/worker: enabled
   mtls:
     mode: STRICT
-{{- end }}
 ---
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
@@ -158,21 +142,9 @@ metadata:
   name: worker
   namespace: {{ .Namespace }}
 spec:
-  {{- if and (eq .DataplaneMode "ambient") .MultiCluster }}
-  targetRefs:
-  - kind: Gateway
-    group: gateway.networking.k8s.io
-    name: {{ .WaypointName }}
-  {{- else if eq .DataplaneMode "ambient" }}
-  targetRefs:
-  - kind: Service
-    group: ""
-    name: worker
-  {{- else }}
   selector:
     matchLabels:
       k-swarm/worker: enabled
-  {{- end }}
   action: ALLOW
   rules:
   - to:
@@ -278,48 +250,4 @@ spec:
   - backendRefs:
     - name: worker
       port: 80
-{{- end }}
-{{- if eq .DataplaneMode "ambient" }}
-{{- if .MultiCluster }}
----
-apiVersion: networking.istio.io/v1
-kind: DestinationRule
-metadata:
-  name: worker
-  namespace: {{ .Namespace }}
-spec:
-  host: worker
-  trafficPolicy:
-    outlierDetection:
-      consecutive5xxErrors: 1
-      interval: 1s
-      baseEjectionTime: 1m
-    loadBalancer:
-      simple: ROUND_ROBIN
-      localityLbSetting:
-        enabled: false # Disable locality load balancing to force failover
-        failoverPriority:
-          - topology.istio.io/cluster
-{{- end }}
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: {{ .WaypointName }}
-  namespace: {{ .Namespace }}
-  labels:
-    istio.io/waypoint-for: service
-spec:
-  gatewayClassName: istio-waypoint
-  {{- if .MultiCluster }}
-  infrastructure:
-    # Propagated by Istio onto the generated waypoint Service so that
-    # other clusters discover it as a global service.
-    labels:
-      istio.io/global: "true"
-  {{- end }}
-  listeners:
-  - name: mesh
-    port: 15008
-    protocol: HBONE
 {{- end }}

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -44,13 +44,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&profiling.MemProfileFile, "mem-profile-file", "mem.prof", "file for memory profiling output")
 	rootCmd.PersistentFlags().StringVar(&profiling.TracingFile, "tracing-file", "trace.out", "file for tracing output")
 
-	//------------
-	// dump flags
-	//------------
-
-	// --stdout flag
-	dumpCmd.Flags().Bool("stdout", false, "Output to stdout")
-
 	//---------------------------
 	// informer and worker flags
 	//---------------------------
@@ -152,13 +145,12 @@ var rootCmd = &cobra.Command{
 }
 
 var dumpCmd = &cobra.Command{
-	Use:          "dump [informer] [worker]",
-	Short:        "Dumps templates to ~/.swarmctl or stdout.",
+	Use:          "dump",
+	Short:        "Dumps every embedded template to ~/.swarmctl.",
 	SilenceUsage: true,
 	Example:      swarmctl.DumpExample(),
 	Aliases:      []string{"d"},
-	ValidArgs:    []string{"informer", "worker"},
-	Args:         cobra.MatchAll(cobra.MaximumNArgs(2), cobra.OnlyValidArgs),
+	Args:         cobra.NoArgs,
 	RunE:         swarmctl.Dump,
 }
 

--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -8,11 +8,9 @@ import (
 
 	// Stdlib
 	"bufio"
-	"bytes"
 	"embed"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
@@ -55,58 +53,42 @@ func Root(cmd *cobra.Command, args []string) error {
 }
 
 //-----------------------------------------------------------------------------
-// Dump writes the informer and/or worker template to ~/.swarmctl
+// Dump writes every embedded asset template to ~/.swarmctl
 //-----------------------------------------------------------------------------
 
 func Dump(cmd *cobra.Command, args []string) error {
 
-	// Get the flags
-	stdout, _ := cmd.Flags().GetBool("stdout")
-
 	// Set the error prefix
 	cmd.SetErrPrefix("\nError:")
 
-	// No args? Default to both
-	if len(args) == 0 {
-		args = []string{"informer", "worker"}
-	}
-
 	// Create ~/.swarmctl
-	if !stdout {
-		if err := os.MkdirAll(util.SwarmDir, 0755); err != nil {
-			return fmt.Errorf("error creating ~/.swarmctl: %w", err)
-		}
+	if err := os.MkdirAll(util.SwarmDir, 0755); err != nil {
+		return fmt.Errorf("error creating ~/.swarmctl: %w", err)
 	}
 
-	// Loop through the components and emit a per-mode variant for each.
-	for _, component := range args {
-		for _, mode := range []string{"sidecar", "ambient"} {
+	// List every file under the embedded assets/ directory.
+	entries, err := Assets.ReadDir("assets")
+	if err != nil {
+		return fmt.Errorf("error reading embedded assets directory: %w", err)
+	}
 
-			name := component + "-" + mode
-
-			// Open the file from the embedded file system
-			fileData, err := Assets.ReadFile(fmt.Sprintf("assets/%s.goyaml", name))
-			if err != nil {
-				return fmt.Errorf("error reading file from embedded FS: %w", err)
-			}
-
-			// Write the content to stdout
-			if stdout {
-				_, err = io.Copy(os.Stdout, bytes.NewReader(fileData))
-				if err != nil {
-					return fmt.Errorf("error writing file data to stdout: %w", err)
-				}
-				continue
-			}
-
-			// Write the contents to ~/.swarmctl/<component>-<mode>.goyaml
-			if err := os.WriteFile(util.SwarmDir+"/"+name+".goyaml", fileData, 0644); err != nil {
-				return fmt.Errorf("error writing file data to ~/.swarmctl/%s.goyaml: %w", name, err)
-			}
-
-			// Print the success message
-			cmd.Printf("Successfully wrote ~/.swarmctl/%s.goyaml\n", name)
+	// Write each file to ~/.swarmctl/<name>.
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
 		}
+		name := entry.Name()
+
+		fileData, err := Assets.ReadFile("assets/" + name)
+		if err != nil {
+			return fmt.Errorf("error reading %s from embedded FS: %w", name, err)
+		}
+
+		if err := os.WriteFile(util.SwarmDir+"/"+name, fileData, 0644); err != nil {
+			return fmt.Errorf("error writing ~/.swarmctl/%s: %w", name, err)
+		}
+
+		cmd.Printf("Successfully wrote ~/.swarmctl/%s\n", name)
 	}
 
 	return nil
@@ -114,14 +96,11 @@ func Dump(cmd *cobra.Command, args []string) error {
 
 func DumpExample() string {
 	return `
-  # Dump the informer and worker templates to ~/.swarmctl
+  # Dump every embedded template to ~/.swarmctl
   swarmctl dump
 
-  # Dump only the informer template to ~/.swarmctl
-  swarmctl d informer
-
-  # Dump the informer and worker templates to stdout
-  swarmctl d --stdout
+  # Same using the command alias
+  swarmctl d
   `
 }
 

--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -78,31 +78,35 @@ func Dump(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Loop through the components
+	// Loop through the components and emit a per-mode variant for each.
 	for _, component := range args {
+		for _, mode := range []string{"sidecar", "ambient"} {
 
-		// Open the file from the embedded file system
-		fileData, err := Assets.ReadFile(fmt.Sprintf("assets/%s.goyaml", component))
-		if err != nil {
-			return fmt.Errorf("error reading file from embedded FS: %w", err)
-		}
+			name := component + "-" + mode
 
-		// Write the content to stdout
-		if stdout {
-			_, err = io.Copy(os.Stdout, bytes.NewReader(fileData))
+			// Open the file from the embedded file system
+			fileData, err := Assets.ReadFile(fmt.Sprintf("assets/%s.goyaml", name))
 			if err != nil {
-				return fmt.Errorf("error writing file data to stdout: %w", err)
+				return fmt.Errorf("error reading file from embedded FS: %w", err)
 			}
-			continue
-		}
 
-		// Write the contents to ~/.swarmctl/<component>.goyaml
-		if err := os.WriteFile(util.SwarmDir+"/"+component+".goyaml", fileData, 0644); err != nil {
-			return fmt.Errorf("error writing file data to ~/.swarmctl/%s.goyaml: %w", component, err)
-		}
+			// Write the content to stdout
+			if stdout {
+				_, err = io.Copy(os.Stdout, bytes.NewReader(fileData))
+				if err != nil {
+					return fmt.Errorf("error writing file data to stdout: %w", err)
+				}
+				continue
+			}
 
-		// Print the success message
-		cmd.Printf("Successfully wrote ~/.swarmctl/%s.goyaml\n", component)
+			// Write the contents to ~/.swarmctl/<component>-<mode>.goyaml
+			if err := os.WriteFile(util.SwarmDir+"/"+name+".goyaml", fileData, 0644); err != nil {
+				return fmt.Errorf("error writing file data to ~/.swarmctl/%s.goyaml: %w", name, err)
+			}
+
+			// Print the success message
+			cmd.Printf("Successfully wrote ~/.swarmctl/%s.goyaml\n", name)
+		}
 	}
 
 	return nil
@@ -214,8 +218,8 @@ func InstallInformer(cmd *cobra.Command, args []string) error {
 	// Set the error prefix
 	cmd.SetErrPrefix("\nError:")
 
-	// Parse the template
-	tmpl, err := util.ParseTemplate(Assets, "informer")
+	// Parse the mode-specific template
+	tmpl, err := util.ParseTemplate(Assets, "informer-"+dataplaneMode)
 	if err != nil {
 		return err
 	}
@@ -401,8 +405,8 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Parse the template
-	tmpl, err := util.ParseTemplate(Assets, "worker")
+	// Parse the mode-specific template
+	tmpl, err := util.ParseTemplate(Assets, "worker-"+dataplaneMode)
 	if err != nil {
 		return err
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,7 +97,10 @@ Key packages:
   per-kubeconfig-context wrapper holding a REST config plus discovery and
   dynamic clients (used for SSA).
 - [cmd/swarmctl/assets/](../cmd/swarmctl/assets/) — embedded `*.goyaml`
-  templates: `informer.goyaml`, `worker.goyaml` and `telemetry.goyaml`.
+  templates: `informer-sidecar.goyaml`, `informer-ambient.goyaml`,
+  `worker-sidecar.goyaml`, `worker-ambient.goyaml` and `telemetry.goyaml`.
+  The informer/worker templates are split per `--dataplane-mode` so each
+  file contains only the manifests relevant to one Istio dataplane mode.
 - [cmd/swarmctl/pkg/profiling/](../cmd/swarmctl/pkg/profiling/) — opt-in CPU,
   memory and trace profiling toggled by global `--cpu-profile`,
   `--mem-profile` and `--tracing` flags.
@@ -152,7 +155,7 @@ sequenceDiagram
     SC-->>User: list matched contexts, prompt y/N
     User-->>SC: y
     loop for each context
-        SC->>SC: render worker.goyaml for i in 1..5 (namespace sidecar-nN)
+        SC->>SC: render worker-sidecar.goyaml for i in 1..5 (namespace sidecar-nN)
         SC->>API: server-side apply manifests (dynamic client)
     end
 ```
@@ -162,7 +165,7 @@ renders the worker template into namespace `<dataplane-mode>-n<i>` (e.g.
 `sidecar-n1`, `ambient-n3`). This is how a single `swarmctl w 1:5` produces
 five Deployments / Services across five namespaces.
 
-The rendered `worker.goyaml` is more than just a Deployment + Service. Per
+The rendered `worker-<mode>.goyaml` is more than just a Deployment + Service. Per
 namespace it can emit, depending on flags:
 
 - Always: `Namespace`, worker `Service`, worker `Deployment`,


### PR DESCRIPTION
## Summary

Splits `cmd/swarmctl/assets/informer.goyaml` and `worker.goyaml` into per-mode variants so each file contains only the manifests relevant to one Istio dataplane mode and no longer needs `{{- if eq .DataplaneMode "ambient" }}` / `{{- if ne ... }}` guards. Also simplifies `swarmctl dump` to a single, arg-less command.

## Why

The two combined templates had become hard to read and to edit safely — every change required mentally tracking which branch was active for each guard. Splitting them eliminates the conditionals entirely and makes the per-mode manifests easy to diff at a glance.

## What changed

**Templates** (under `cmd/swarmctl/assets/`):
- New: `informer-sidecar.goyaml`, `informer-ambient.goyaml`, `worker-sidecar.goyaml`, `worker-ambient.goyaml` — each is a flat copy of the relevant branches with `DataplaneMode` guards inlined and removed.
- Removed: `informer.goyaml`, `worker.goyaml`.
- `telemetry.goyaml` is unchanged (no dataplane branching).

**Code** (`cmd/swarmctl/pkg/swarmctl/swarmctl.go`):
- `InstallInformer` / `InstallWorker` now load `<component>-<dataplane-mode>.goyaml` from the embedded FS. User overrides at `~/.swarmctl/<component>-<mode>.goyaml` continue to work unchanged via `util.ParseTemplate` (signature unchanged).
- `Dump` is simplified: no `--stdout`, no `informer`/`worker` args. It enumerates the embedded `assets/` directory and copies every file verbatim to `~/.swarmctl/<name>`, so future templates are picked up automatically with no code changes.

**CLI** (`cmd/swarmctl/cmd/cmd.go`):
- `dumpCmd` drops the `--stdout` flag, the positional args and `ValidArgs` (`Args: cobra.NoArgs`).

**Docs** (`docs/architecture.md`):
- References to `informer.goyaml` / `worker.goyaml` updated to the per-mode names.

## Verification

- `go build ./...`, `go vet ./...` and `golangci-lint run ./cmd/swarmctl/...` all clean.
- Render parity: captured `swarmctl {i, w 1:2} --dry-run --dataplane-mode {sidecar,ambient}` for every `--ingress-mode {none,shared,dedicated}` (plus `--multi-cluster` and with/without `--istio-revision`) before and after the split. `diff -ruN` is empty — output is byte-identical.
- `swarmctl dump` writes the five expected files (`informer-{sidecar,ambient}.goyaml`, `worker-{sidecar,ambient}.goyaml`, `telemetry.goyaml`) to `~/.swarmctl/`.
