### PR TITLE
Rename worker Kubernetes resources to peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Expose service `1` via a per-namespace Gateway API `Gateway`/`HTTPRoute`:
 swarmctl w --context 'kind-*' 1:1 --dataplane-mode ambient --ingress-mode dedicated
 ```
 
-Enable cross-cluster failover for ambient-mode workers (labels the worker
+Enable cross-cluster failover for ambient-mode workers (labels the peer
 and waypoint Services with `istio.io/global=true` and emits a
 `DestinationRule` with locality failover by `topology.istio.io/cluster`):
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -176,7 +176,7 @@ func main() {
 	// Run as a worker
 	if flags.EnableWorker {
 		wg.Add(1)
-		ctrl.Log.WithName("main").Info("Starting worker")
+		ctrl.Log.WithName("main").Info("Starting peer")
 		go worker.Start(ctx, &wg, flags)
 	}
 

--- a/cmd/swarmctl/assets/worker-ambient.goyaml
+++ b/cmd/swarmctl/assets/worker-ambient.goyaml
@@ -21,35 +21,35 @@ metadata:
     {{- if .MultiCluster }}
     istio.io/global: "true"
     {{- end }}
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   ports:
   - name: http
     port: 80
     protocol: TCP
-    targetPort: worker
+    targetPort: peer
   selector:
-    k-swarm/worker: enabled
+    k-swarm/peer: enabled
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   replicas: {{ .Replicas }}
   selector:
     matchLabels:
-      k-swarm/worker: enabled
+      k-swarm/peer: enabled
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        app: worker
+        app: peer
         version: v1
-        k-swarm/worker: enabled
+        k-swarm/peer: enabled
     spec:
       containers:
       - args:
@@ -91,7 +91,7 @@ spec:
         name: manager
         ports:
         - containerPort: 8082
-          name: worker
+          name: peer
           protocol: TCP
         securityContext:
           allowPrivilegeEscalation: false
@@ -109,7 +109,7 @@ spec:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   {{- if .MultiCluster }}
@@ -121,7 +121,7 @@ spec:
   targetRefs:
   - kind: Service
     group: ""
-    name: worker
+    name: peer
   {{- end }}
   action: ALLOW
   rules:
@@ -133,12 +133,12 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   duration: 24h0m0s
   renewBefore: 12h0m0s
-  secretName: worker-{{ .Namespace }}
+  secretName: peer-{{ .Namespace }}
   dnsNames:
   - '{{ .Namespace }}.demo.lab'
   issuerRef:
@@ -156,7 +156,7 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   selector:
@@ -170,16 +170,16 @@ spec:
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      credentialName: worker-{{ .Namespace }}
+      credentialName: peer-{{ .Namespace }}
 ---
 apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   gateways:
-  - worker
+  - peer
   hosts:
   - '{{ .Namespace }}.demo.lab'
   http:
@@ -187,7 +187,7 @@ spec:
     - port: 443
     route:
     - destination:
-        host: 'worker.{{ .Namespace }}.svc.{{ .ClusterDomain }}'
+        host: 'peer.{{ .Namespace }}.svc.{{ .ClusterDomain }}'
         port:
           number: 80
       weight: 100
@@ -196,7 +196,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: worker-ingress
+  name: peer-ingress
   namespace: {{ .Namespace }}
 spec:
   gatewayClassName: istio
@@ -209,7 +209,7 @@ spec:
       mode: Terminate
       certificateRefs:
       - kind: Secret
-        name: worker-{{ .Namespace }}
+        name: peer-{{ .Namespace }}
     allowedRoutes:
       namespaces:
         from: Same
@@ -217,16 +217,16 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   parentRefs:
-  - name: worker-ingress
+  - name: peer-ingress
   hostnames:
   - '{{ .Namespace }}.demo.lab'
   rules:
   - backendRefs:
-    - name: worker
+    - name: peer
       port: 80
 {{- end }}
 {{- if .MultiCluster }}
@@ -234,10 +234,10 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
-  host: worker
+  host: peer
   trafficPolicy:
     outlierDetection:
       consecutive5xxErrors: 1

--- a/cmd/swarmctl/assets/worker-sidecar.goyaml
+++ b/cmd/swarmctl/assets/worker-sidecar.goyaml
@@ -15,27 +15,27 @@ kind: Service
 metadata:
   labels:
     app: k-swarm
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   ports:
   - name: http
     port: 80
     protocol: TCP
-    targetPort: worker
+    targetPort: peer
   selector:
-    k-swarm/worker: enabled
+    k-swarm/peer: enabled
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   replicas: {{ .Replicas }}
   selector:
     matchLabels:
-      k-swarm/worker: enabled
+      k-swarm/peer: enabled
   template:
     metadata:
       annotations:
@@ -45,9 +45,9 @@ spec:
         sidecar.istio.io/proxyMemory: 64Mi
         sidecar.istio.io/proxyMemoryLimit: 512Mi
       labels:
-        app: worker
+        app: peer
         version: v1
-        k-swarm/worker: enabled
+        k-swarm/peer: enabled
     spec:
       containers:
       - args:
@@ -89,7 +89,7 @@ spec:
         name: manager
         ports:
         - containerPort: 8082
-          name: worker
+          name: peer
           protocol: TCP
         securityContext:
           allowPrivilegeEscalation: false
@@ -107,10 +107,10 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
-  host: worker
+  host: peer
   trafficPolicy:
     connectionPool:
       http:
@@ -127,24 +127,24 @@ spec:
 apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   selector:
     matchLabels:
-      k-swarm/worker: enabled
+      k-swarm/peer: enabled
   mtls:
     mode: STRICT
 ---
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   selector:
     matchLabels:
-      k-swarm/worker: enabled
+      k-swarm/peer: enabled
   action: ALLOW
   rules:
   - to:
@@ -155,12 +155,12 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   duration: 24h0m0s
   renewBefore: 12h0m0s
-  secretName: worker-{{ .Namespace }}
+  secretName: peer-{{ .Namespace }}
   dnsNames:
   - '{{ .Namespace }}.demo.lab'
   issuerRef:
@@ -178,7 +178,7 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   selector:
@@ -192,16 +192,16 @@ spec:
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      credentialName: worker-{{ .Namespace }}
+      credentialName: peer-{{ .Namespace }}
 ---
 apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   gateways:
-  - worker
+  - peer
   hosts:
   - '{{ .Namespace }}.demo.lab'
   http:
@@ -209,7 +209,7 @@ spec:
     - port: 443
     route:
     - destination:
-        host: 'worker.{{ .Namespace }}.svc.{{ .ClusterDomain }}'
+        host: 'peer.{{ .Namespace }}.svc.{{ .ClusterDomain }}'
         port:
           number: 80
       weight: 100
@@ -218,7 +218,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: worker-ingress
+  name: peer-ingress
   namespace: {{ .Namespace }}
 spec:
   gatewayClassName: istio
@@ -231,7 +231,7 @@ spec:
       mode: Terminate
       certificateRefs:
       - kind: Secret
-        name: worker-{{ .Namespace }}
+        name: peer-{{ .Namespace }}
     allowedRoutes:
       namespaces:
         from: Same
@@ -239,15 +239,15 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: worker
+  name: peer
   namespace: {{ .Namespace }}
 spec:
   parentRefs:
-  - name: worker-ingress
+  - name: peer-ingress
   hostnames:
   - '{{ .Namespace }}.demo.lab'
   rules:
   - backendRefs:
-    - name: worker
+    - name: peer
       port: 80
 {{- end }}

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -117,10 +117,10 @@ func init() {
 		c.PersistentFlags().Bool("dry-run", false, "Render manifests to stdout without applying them or contacting the cluster.")
 
 		// --multi-cluster flag
-		c.PersistentFlags().Bool("multi-cluster", false, "Enable cross-cluster failover for ambient mode: labels the worker and waypoint Services with istio.io/global=true and emits a DestinationRule with locality failover by topology.istio.io/cluster.")
+		c.PersistentFlags().Bool("multi-cluster", false, "Enable cross-cluster failover for ambient mode: labels the peer and waypoint Services with istio.io/global=true and emits a DestinationRule with locality failover by topology.istio.io/cluster.")
 
 		// --log-responses flag
-		c.PersistentFlags().Bool("log-responses", false, "If set, the worker logs the raw JSON response bodies received from the informer's /services endpoint and from peer workers' /data endpoint.")
+		c.PersistentFlags().Bool("log-responses", false, "If set, the worker logs the raw JSON response bodies received from the informer's /services endpoint and from peer pods' /data endpoint.")
 	}
 }
 
@@ -181,6 +181,7 @@ var informerTelemetryCmd = &cobra.Command{
 var workerCmd = &cobra.Command{
 	Use:               "worker <start:end>",
 	Short:             "Installs the worker's manifests.",
+	Long:              "Installs the worker's manifests. Each invocation renders a Deployment named 'peer' (and matching Service) into namespace <dataplane-mode>-n<i> for every i in <start:end>; pods carry the label k-swarm/peer=enabled.",
 	SilenceUsage:      true,
 	Example:           swarmctl.InstallWorkerExample(),
 	Aliases:           []string{"w"},

--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -502,13 +502,13 @@ func InstallWorkerExample() string {
   # Install the workers 1 to 1 to all contexts that match a regex in Istio ambient mode
   swarmctl w 1:1 --dataplane-mode ambient --context 'kind-pizza-.*'
 
-  # Expose the worker Service via the shared istio-system/istio-nsgw gateway.
+  # Expose the peer Service via the shared istio-system/istio-nsgw gateway.
   swarmctl w 1:1 --dataplane-mode sidecar --context 'kind-pasta-.*' --ingress-mode shared
 
-  # Expose the worker Service via a dedicated Gateway API Gateway+HTTPRoute.
+  # Expose the peer Service via a dedicated Gateway API Gateway+HTTPRoute.
   swarmctl w 1:1 --dataplane-mode ambient --context 'kind-pasta-.*' --ingress-mode dedicated
 
-  # Enable cross-cluster failover for ambient-mode workers: labels the worker
+  # Enable cross-cluster failover for ambient-mode workers: labels the peer
   # and waypoint Services with istio.io/global=true and emits a DestinationRule
   # with locality failover by topology.istio.io/cluster (ambient-only).
   swarmctl w 1:1 --dataplane-mode ambient --context 'kind-pasta-.*' --multi-cluster

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
         control-plane: controller-manager
         app.kubernetes.io/name: k-swarm
         k-swarm/informer: enabled
-        k-swarm/worker: enabled
+        k-swarm/peer: enabled
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.
@@ -94,7 +94,7 @@ spec:
               fieldPath: spec.nodeName
         ports:
         - containerPort: 8082
-          name: worker
+          name: peer
           protocol: TCP
         - containerPort: 8083
           name: informer
@@ -147,14 +147,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: worker
+  name: peer
   labels:
     app: k-swarm
 spec:
   selector:
-    k-swarm/worker: enabled
+    k-swarm/peer: enabled
   ports:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: worker
+      targetPort: peer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,13 +45,13 @@ flowchart LR
             Inf[informer Deployment]
         end
         subgraph NS1[namespace sidecar-n1]
-            W1[worker Deployment]
+            W1[peer Deployment]
         end
         subgraph NS2[namespace sidecar-n2]
-            W2[worker Deployment]
+            W2[peer Deployment]
         end
         subgraph NSN[namespace sidecar-nN]
-            WN[worker Deployment]
+            WN[peer Deployment]
         end
     end
 
@@ -135,7 +135,7 @@ Key persistent flags shared by `informer` and `worker` (and inherited by their
 | `--node-selector` | _empty_ | Inline YAML node selector for the Deployment pod spec. |
 | `--waypoint-name` | `waypoint` | Name of the per-namespace ambient waypoint Gateway. |
 | `--ingress-mode` | `none` | `none`, `shared` (Istio `Gateway`/`VirtualService` selecting `istio: nsgw`) or `dedicated` (per-namespace Gateway API `Gateway`/`HTTPRoute`). |
-| `--multi-cluster` | `false` | Ambient-only: labels worker and waypoint Services with `istio.io/global=true` and emits a `DestinationRule` with locality failover by `topology.istio.io/cluster`. |
+| `--multi-cluster` | `false` | Ambient-only: labels peer and waypoint Services with `istio.io/global=true` and emits a `DestinationRule` with locality failover by `topology.istio.io/cluster`. |
 | `--log-responses` | `false` | Renders the worker manifest with `--worker-log-responses`, causing each pod to log raw JSON bodies received from the informer and peers. |
 | `--dry-run` | `false` | Render YAML to stdout; skip cluster discovery and apply. |
 | `--yes` | `false` | Skip the confirmation prompt before applying. |
@@ -168,16 +168,16 @@ five Deployments / Services across five namespaces.
 The rendered `worker-<mode>.goyaml` is more than just a Deployment + Service. Per
 namespace it can emit, depending on flags:
 
-- Always: `Namespace`, worker `Service`, worker `Deployment`,
+- Always: `Namespace`, peer `Service`, peer `Deployment`,
   `AuthorizationPolicy` allowing `GET /data`, and a cert-manager `Certificate`
   (replicated to `istio-system` for ingress TLS).
 - Sidecar mode (`--dataplane-mode sidecar`): a `DestinationRule` with locality
   load balancing and outlier detection plus a `STRICT` mTLS
   `PeerAuthentication`.
 - Ambient mode (`--dataplane-mode ambient`): a per-namespace waypoint
-  `Gateway` (`gatewayClassName: istio-waypoint`); the worker Service is
+  `Gateway` (`gatewayClassName: istio-waypoint`); the peer Service is
   labeled `istio.io/use-waypoint`.
-- Ambient + `--multi-cluster`: worker and waypoint Services are labeled
+- Ambient + `--multi-cluster`: peer and waypoint Services are labeled
   `istio.io/global=true` and an extra `DestinationRule` with locality
   failover by `topology.istio.io/cluster` is emitted.
 - `--ingress-mode shared`: an Istio `Gateway`/`VirtualService` pair selecting
@@ -263,7 +263,9 @@ Notable details:
 
 Source: [pkg/worker/worker.go](../pkg/worker/worker.go).
 
-A worker pod is **simultaneously a client and a server**:
+The `worker` is the in-pod process; its Deployment and Service are rendered
+under the name `peer` in each `<dataplane-mode>-n<i>` namespace. A worker pod
+is **simultaneously a client and a server**:
 
 - **Server** (`server`): a Gin handler at `GET /data` that returns a small JSON
   blob describing the pod (`CLUSTER_NAME`, `POD_NAME`, `POD_NAMESPACE`,

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	serviceList = []string{}
-	log         = ctrl.Log.WithName("worker")
+	log         = ctrl.Log.WithName("peer")
 )
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Rename the rendered Kubernetes objects from `worker` to `peer` across the worker templates (sidecar and ambient), the local dev manager manifest, and the operator-facing examples and architecture docs.

The CLI verb (`swarmctl worker` / `w`), the Go package (`pkg/worker`), and the manager flags (`--enable-worker`, `--worker-bind-address`, `--worker-request-interval`, `--worker-log-responses`) are intentionally **unchanged** — only K8s-visible identifiers move. This matches the conceptual split: `swarmctl worker` deploys a workload; once running, those pods are peers in a mesh.

## What changed

In `cmd/swarmctl/assets/worker-sidecar.goyaml`, `cmd/swarmctl/assets/worker-ambient.goyaml` and `config/manager/manager.yaml`:

- `metadata.name: worker` → `peer` on Service, Deployment, DestinationRule, PeerAuthentication, AuthorizationPolicy, Certificate, Gateway, VirtualService, HTTPRoute.
- Pod label `app: worker` → `app: peer` (drives Istio `source_app` / `destination_app` metric labels).
- Selector key `k-swarm/worker: enabled` → `k-swarm/peer: enabled`.
- Container/Service port name `worker` → `peer` (port number 8082 unchanged).
- Cert-manager Secret `worker-<ns>` → `peer-<ns>`, kept in lock-step with Gateway `credentialName` and HTTPRoute `certificateRefs`.
- DestinationRule `host` and VirtualService destination host follow the Service rename.
- Dedicated-ingress Gateway `worker-ingress` → `peer-ingress`.
- Service label `app: k-swarm` is **preserved** — it is load-bearing for the informer's service discovery (see `internal/controller/service_controller.go`).

Docs and help text updated to match in `cmd/swarmctl/cmd/cmd.go`, `cmd/swarmctl/pkg/swarmctl/swarmctl.go`, `docs/architecture.md` and `README.md`. Added a `Long` description on `swarmctl worker` noting the rendered Deployment is named `peer` to cushion the CLI/resource asymmetry.

## Verification

- `go build ./cmd/swarmctl` and `go vet ./...` clean.
- Dry-run renders for all four template conditional branches: sidecar, sidecar + `--ingress-mode shared`, ambient + `--ingress-mode dedicated`, ambient + `--multi-cluster`. All emit `peer` consistently; cert `secretName` matches `credentialName`/`certificateRefs`; VS destination host is `peer.<ns>.svc.cluster.local`.
- Only remaining `worker` tokens in rendered output are the intentionally-preserved CLI flag args (`--enable-worker`, `--worker-bind-address`, `--worker-request-interval`).

## Breaking change

Anyone with saved Prometheus / Grafana queries filtering on `app="worker"` / `destination_app="worker"`, or `kubectl` aliases referencing `svc/worker`, will need to update them to `peer`.
