### PR TITLE
Normalize labels and prefix cluster-scoped RBAC names in swarmctl assets

### DIFF
--- a/cmd/swarmctl/assets/informer-ambient.goyaml
+++ b/cmd/swarmctl/assets/informer-ambient.goyaml
@@ -80,7 +80,7 @@ metadata:
     app.kubernetes.io/managed-by: swarmctl
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
-  name: manager-role
+  name: k-swarm-informer-manager-role
 rules:
 - apiGroups:
   - ""
@@ -130,7 +130,7 @@ metadata:
     app.kubernetes.io/managed-by: swarmctl
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
-  name: metrics-reader
+  name: k-swarm-informer-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -166,11 +166,11 @@ metadata:
     app.kubernetes.io/managed-by: swarmctl
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
-  name: manager-rolebinding
+  name: k-swarm-informer-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: k-swarm-informer-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/cmd/swarmctl/assets/informer-ambient.goyaml
+++ b/cmd/swarmctl/assets/informer-ambient.goyaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
     {{- if .IstioRevision }}
     istio.io/rev: {{ .IstioRevision }}
     {{- end }}
@@ -17,10 +20,9 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: k-swarm
     app.kubernetes.io/instance: controller-manager-sa
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: controller-manager
   namespace: informer
@@ -30,10 +32,9 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: k-swarm
     app.kubernetes.io/instance: leader-election-role
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: role
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: leader-election-role
   namespace: informer
@@ -73,6 +74,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/instance: manager-role
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: manager-role
 rules:
 - apiGroups:
@@ -119,10 +126,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: k-swarm
     app.kubernetes.io/instance: metrics-reader
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: metrics-reader
 rules:
@@ -136,10 +142,9 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: k-swarm
     app.kubernetes.io/instance: leader-election-rolebinding
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: leader-election-rolebinding
   namespace: informer
@@ -157,10 +162,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: k-swarm
     app.kubernetes.io/instance: manager-rolebinding
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: manager-rolebinding
 roleRef:
@@ -177,10 +181,9 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: k-swarm
     app.kubernetes.io/instance: controller-manager-metrics-service
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: service
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
     control-plane: controller-manager
   name: controller-manager-metrics-service
@@ -200,6 +203,9 @@ metadata:
   name: informer
   namespace: informer
   labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
     istio.io/use-waypoint: {{ .WaypointName }}
 spec:
   ports:
@@ -213,6 +219,10 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer
   namespace: informer
 spec:
@@ -289,6 +299,10 @@ spec:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer
   namespace: informer
 spec:
@@ -309,6 +323,9 @@ metadata:
   name: {{ .WaypointName }}
   namespace: informer
   labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
     istio.io/waypoint-for: service
 spec:
   gatewayClassName: istio-waypoint
@@ -321,6 +338,10 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer
   namespace: informer
 spec:
@@ -337,6 +358,10 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer
   namespace: informer
 spec:
@@ -356,6 +381,10 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer-ingress
   namespace: informer
 spec:
@@ -372,6 +401,10 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer
   namespace: informer
 spec:

--- a/cmd/swarmctl/assets/informer-sidecar.goyaml
+++ b/cmd/swarmctl/assets/informer-sidecar.goyaml
@@ -78,7 +78,7 @@ metadata:
     app.kubernetes.io/managed-by: swarmctl
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
-  name: manager-role
+  name: k-swarm-informer-manager-role
 rules:
 - apiGroups:
   - ""
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: swarmctl
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
-  name: metrics-reader
+  name: k-swarm-informer-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -164,11 +164,11 @@ metadata:
     app.kubernetes.io/managed-by: swarmctl
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
-  name: manager-rolebinding
+  name: k-swarm-informer-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: k-swarm-informer-manager-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/cmd/swarmctl/assets/informer-sidecar.goyaml
+++ b/cmd/swarmctl/assets/informer-sidecar.goyaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
     {{- if .IstioRevision }}
     istio.io/rev: {{ .IstioRevision }}
     {{- else }}
@@ -15,10 +18,9 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: k-swarm
     app.kubernetes.io/instance: controller-manager-sa
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: controller-manager
   namespace: informer
@@ -28,10 +30,9 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: k-swarm
     app.kubernetes.io/instance: leader-election-role
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: role
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: leader-election-role
   namespace: informer
@@ -71,6 +72,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/instance: manager-role
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: manager-role
 rules:
 - apiGroups:
@@ -117,10 +124,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: k-swarm
     app.kubernetes.io/instance: metrics-reader
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: metrics-reader
 rules:
@@ -134,10 +140,9 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: k-swarm
     app.kubernetes.io/instance: leader-election-rolebinding
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: leader-election-rolebinding
   namespace: informer
@@ -155,10 +160,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: k-swarm
     app.kubernetes.io/instance: manager-rolebinding
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: manager-rolebinding
 roleRef:
@@ -175,10 +179,9 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: k-swarm
     app.kubernetes.io/instance: controller-manager-metrics-service
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: service
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
     control-plane: controller-manager
   name: controller-manager-metrics-service
@@ -195,6 +198,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer
   namespace: informer
 spec:
@@ -209,6 +216,10 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer
   namespace: informer
 spec:
@@ -289,6 +300,10 @@ spec:
 apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer
   namespace: informer
 spec:
@@ -301,6 +316,10 @@ spec:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer
   namespace: informer
 spec:
@@ -318,6 +337,10 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer
   namespace: informer
 spec:
@@ -334,6 +357,10 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer
   namespace: informer
 spec:
@@ -353,6 +380,10 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer-ingress
   namespace: informer
 spec:
@@ -369,6 +400,10 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: informer
+    app.kubernetes.io/part-of: k-swarm
   name: informer
   namespace: informer
 spec:

--- a/cmd/swarmctl/assets/telemetry.goyaml
+++ b/cmd/swarmctl/assets/telemetry.goyaml
@@ -8,6 +8,11 @@
 apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: telemetry
+    app.kubernetes.io/part-of: k-swarm
   name: istio-metrics
   namespace: {{ .Namespace }}
 spec:
@@ -30,6 +35,11 @@ spec:
 apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
+  labels:
+    app.kubernetes.io/component: telemetry
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: telemetry
+    app.kubernetes.io/part-of: k-swarm
   name: istio-metrics
   namespace: {{ .Namespace }}
 spec:

--- a/cmd/swarmctl/assets/worker-ambient.goyaml
+++ b/cmd/swarmctl/assets/worker-ambient.goyaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
     {{- if .IstioRevision }}
     istio.io/rev: {{ .IstioRevision }}
     {{- end }}
@@ -17,6 +20,9 @@ kind: Service
 metadata:
   labels:
     app: k-swarm
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
     istio.io/use-waypoint: {{ .WaypointName }}
     {{- if .MultiCluster }}
     istio.io/global: "true"
@@ -35,6 +41,10 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -109,6 +119,10 @@ spec:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -133,6 +147,10 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -156,6 +174,10 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -175,6 +197,10 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -196,6 +222,10 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer-ingress
   namespace: {{ .Namespace }}
 spec:
@@ -217,6 +247,10 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -234,6 +268,10 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -257,6 +295,9 @@ metadata:
   name: {{ .WaypointName }}
   namespace: {{ .Namespace }}
   labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
     istio.io/waypoint-for: service
 spec:
   gatewayClassName: istio-waypoint

--- a/cmd/swarmctl/assets/worker-sidecar.goyaml
+++ b/cmd/swarmctl/assets/worker-sidecar.goyaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
     {{- if .IstioRevision }}
     istio.io/rev: {{ .IstioRevision }}
     {{- else }}
@@ -15,6 +18,9 @@ kind: Service
 metadata:
   labels:
     app: k-swarm
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -29,6 +35,10 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -107,6 +117,10 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -127,6 +141,10 @@ spec:
 apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -139,6 +157,10 @@ spec:
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -155,6 +177,10 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -178,6 +204,10 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -197,6 +227,10 @@ spec:
 apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -218,6 +252,10 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer-ingress
   namespace: {{ .Namespace }}
 spec:
@@ -239,6 +277,10 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: swarmctl
+    app.kubernetes.io/name: peer
+    app.kubernetes.io/part-of: k-swarm
   name: peer
   namespace: {{ .Namespace }}
 spec:


### PR DESCRIPTION
## What

Two related asset-only changes:

1. **Normalize `app.kubernetes.io/*` labels** on every object swarmctl applies.
2. **Prefix cluster-scoped RBAC names** with `k-swarm-informer-` to avoid colliding with other kubebuilder-based operators in the same cluster.

Pure asset edit — no Go changes, no behavior changes beyond the rename.

## Why

- Foundation for a future `swarmctl delete` subcommand (label selector `app.kubernetes.io/managed-by=swarmctl` finds every object swarmctl ever created, including cluster-scoped RBAC).
- Today the kubebuilder-scaffolded RBAC docs claim `managed-by: kustomize` (wrong — swarmctl is the applier) and carry a useless `created-by: k-swarm` label. Most other docs (worker-side, ingress branches, telemetry) had no `app.kubernetes.io/*` labels at all.
- The kubebuilder-default ClusterRole names `manager-role`, `metrics-reader` and the binding `manager-rolebinding` are used by every kubebuilder project. Two swarmctl-style operators in one cluster would silently overwrite each other's RBAC via server-side apply.

## What changed

### Labels (every templated document, all 5 asset files)

| Label | Value | Notes |
|---|---|---|
| `app.kubernetes.io/managed-by` | `swarmctl` | was `kustomize` on RBAC docs, absent elsewhere |
| `app.kubernetes.io/part-of` | `k-swarm` | UI grouping (Kiali / Argo CD / Lens) |
| `app.kubernetes.io/name` | `informer` / `peer` / `telemetry` | was the *kind* (`serviceaccount`, `role`, ...) on kubebuilder docs — now the *app*, per spec |

Dropped everywhere: `app.kubernetes.io/created-by` (kubebuilder scaffolding cargo, redundant with `managed-by`).

Kept where present: `app.kubernetes.io/instance` and `app.kubernetes.io/component`.

### Cluster-scoped RBAC renames (informer assets only)

| Kind | Old name | New name |
|---|---|---|
| `ClusterRole` | `manager-role` | `k-swarm-informer-manager-role` |
| `ClusterRole` | `metrics-reader` | `k-swarm-informer-metrics-reader` |
| `ClusterRoleBinding` | `manager-rolebinding` | `k-swarm-informer-manager-rolebinding` |

The binding's `roleRef.name` is updated in lockstep. Namespace-scoped objects are unaffected.

## Migration

Existing installs will be left with orphan `ClusterRole`/`ClusterRoleBinding` under the old names after upgrade. They carry no `managed-by: swarmctl` label, so the future delete sweep won't catch them. One-time manual cleanup before re-installing:

```sh
kubectl delete clusterrole manager-role metrics-reader
kubectl delete clusterrolebinding manager-rolebinding
```

## Out of scope (deliberate)

- The `delete` subcommand itself — separate PR.
- Pod-template label propagation — would force a rolling restart on next apply; trivial follow-up.
- `app.kubernetes.io/version` — not requested; can add later.
- `config/rbac/*.yaml` and the `controller-gen rbac:roleName=manager-role` call in the Makefile — those are kubebuilder source, not applied by swarmctl. Renaming them needs a coordinated kustomize `namePrefix` change.

## Verification

- `go build ./cmd/swarmctl` — OK.
- 17 `--dry-run` combinations (every dataplane × ingress mode, plus telemetry on/off, plus multi-cluster) all satisfy:
  - `count(^kind:) == count(managed-by: swarmctl) == count(part-of: k-swarm)`
  - `count(created-by) == 0`
  - `count(managed-by: kustomize) == 0`
- Rendered output parses as valid YAML for representative combinations.
- Spot-check confirms the 3 renamed objects + the cross-reference all land on the prefixed names.