### PR TITLE
Prefix swarmctl-managed namespaces with swarm-

### DIFF
--- a/cmd/swarmctl/assets/informer-ambient.goyaml
+++ b/cmd/swarmctl/assets/informer-ambient.goyaml
@@ -13,13 +13,13 @@ metadata:
     {{- if .IstioRevision }}
     istio-injection: disabled
     {{- end }}
-  name: informer
+  name: swarm-informer
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: informer
-  namespace: informer
+  namespace: swarm-informer
   labels:
     app.kubernetes.io/managed-by: swarmctl
     app.kubernetes.io/name: informer
@@ -42,7 +42,7 @@ metadata:
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: informer
-  namespace: informer
+  namespace: swarm-informer
 spec:
   replicas: {{ .Replicas }}
   selector:
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: informer
-  namespace: informer
+  namespace: swarm-informer
 spec:
   targetRefs:
   - kind: Service
@@ -139,7 +139,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: {{ .WaypointName }}
-  namespace: informer
+  namespace: swarm-informer
   labels:
     app.kubernetes.io/managed-by: swarmctl
     app.kubernetes.io/name: informer

--- a/cmd/swarmctl/assets/informer-common.goyaml
+++ b/cmd/swarmctl/assets/informer-common.goyaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: controller-manager
-  namespace: informer
+  namespace: swarm-informer
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: leader-election-role
-  namespace: informer
+  namespace: swarm-informer
 rules:
 - apiGroups:
   - ""
@@ -132,7 +132,7 @@ metadata:
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: leader-election-rolebinding
-  namespace: informer
+  namespace: swarm-informer
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -140,7 +140,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: informer
+  namespace: swarm-informer
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -159,7 +159,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-manager
-  namespace: informer
+  namespace: swarm-informer
 ---
 apiVersion: v1
 kind: Service
@@ -172,7 +172,7 @@ metadata:
     app.kubernetes.io/part-of: k-swarm
     control-plane: controller-manager
   name: controller-manager-metrics-service
-  namespace: informer
+  namespace: swarm-informer
 spec:
   ports:
   - name: https
@@ -191,7 +191,7 @@ metadata:
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: informer
-  namespace: informer
+  namespace: swarm-informer
 spec:
   selector:
     istio: nsgw
@@ -211,7 +211,7 @@ metadata:
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: informer
-  namespace: informer
+  namespace: swarm-informer
 spec:
   gateways:
   - informer
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: informer-ingress
-  namespace: informer
+  namespace: swarm-informer
 spec:
   gatewayClassName: istio
   listeners:
@@ -254,7 +254,7 @@ metadata:
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: informer
-  namespace: informer
+  namespace: swarm-informer
 spec:
   parentRefs:
   - name: informer-ingress

--- a/cmd/swarmctl/assets/informer-sidecar.goyaml
+++ b/cmd/swarmctl/assets/informer-sidecar.goyaml
@@ -11,7 +11,7 @@ metadata:
     {{- else }}
     istio-injection: enabled
     {{- end }}
-  name: informer
+  name: swarm-informer
 ---
 apiVersion: v1
 kind: Service
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: informer
-  namespace: informer
+  namespace: swarm-informer
 spec:
   ports:
   - name: http
@@ -39,7 +39,7 @@ metadata:
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: informer
-  namespace: informer
+  namespace: swarm-informer
 spec:
   replicas: {{ .Replicas }}
   selector:
@@ -123,7 +123,7 @@ metadata:
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: informer
-  namespace: informer
+  namespace: swarm-informer
 spec:
   selector:
     matchLabels:
@@ -139,7 +139,7 @@ metadata:
     app.kubernetes.io/name: informer
     app.kubernetes.io/part-of: k-swarm
   name: informer
-  namespace: informer
+  namespace: swarm-informer
 spec:
   selector:
     matchLabels:

--- a/cmd/swarmctl/assets/worker-ambient.goyaml
+++ b/cmd/swarmctl/assets/worker-ambient.goyaml
@@ -67,7 +67,7 @@ spec:
         - --enable-informer=false
         - --enable-worker=true
         - --worker-bind-address=:8082
-        - --informer-url=http://informer.informer
+        - --informer-url=http://informer.swarm-informer
         - --informer-poll-interval=60s
         - --worker-request-interval=2s
         {{- if .LogResponses }}

--- a/cmd/swarmctl/assets/worker-sidecar.goyaml
+++ b/cmd/swarmctl/assets/worker-sidecar.goyaml
@@ -65,7 +65,7 @@ spec:
         - --enable-informer=false
         - --enable-worker=true
         - --worker-bind-address=:8082
-        - --informer-url=http://informer.informer
+        - --informer-url=http://informer.swarm-informer
         - --informer-poll-interval=60s
         - --worker-request-interval=2s
         {{- if .LogResponses }}

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -181,7 +181,7 @@ var informerTelemetryCmd = &cobra.Command{
 var workerCmd = &cobra.Command{
 	Use:               "worker <start:end>",
 	Short:             "Installs the worker's manifests.",
-	Long:              "Installs the worker's manifests. Each invocation renders a Deployment named 'peer' (and matching Service) into namespace <dataplane-mode>-n<i> for every i in <start:end>; pods carry the label k-swarm/peer=enabled.",
+	Long:              "Installs the worker's manifests. Each invocation renders a Deployment named 'peer' (and matching Service) into namespace swarm-<dataplane-mode>-n<i> for every i in <start:end>; pods carry the label k-swarm/peer=enabled.",
 	SilenceUsage:      true,
 	Example:           swarmctl.InstallWorkerExample(),
 	Aliases:           []string{"w"},

--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -322,7 +322,7 @@ func InstallInformerTelemetry(cmd *cobra.Command, args []string) error {
 			Namespace string
 		}{
 			OnOff:     args[0],
-			Namespace: "informer",
+			Namespace: "swarm-informer",
 		})
 		if err != nil {
 			return err
@@ -420,7 +420,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 				fmt.Printf("\n")
 			}
 
-			namespace := fmt.Sprintf("%s-n%d", dataplaneMode, i)
+			namespace := fmt.Sprintf("swarm-%s-n%d", dataplaneMode, i)
 
 			// Render the template
 			docs, err := util.RenderTemplate(tmpl, struct {
@@ -478,7 +478,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 func InstallWorkerExample() string {
 	return `
   # Install the workers 1 to 1 to the current context
-  # (namespaces follow <mode>-n<index>, e.g. sidecar-n1)
+  # (namespaces follow swarm-<mode>-n<index>, e.g. swarm-sidecar-n1)
   swarmctl worker 1:1 --dataplane-mode sidecar
 
   # Same using the command alias
@@ -564,7 +564,7 @@ func InstallWorkerTelemetry(cmd *cobra.Command, args []string) error {
 				Namespace string
 			}{
 				OnOff:     args[1],
-				Namespace: fmt.Sprintf("%s-n%d", dataplaneMode, i),
+				Namespace: fmt.Sprintf("swarm-%s-n%d", dataplaneMode, i),
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
Rename all namespaces created by `swarmctl` so they are clearly identifiable as belonging to k-swarm:

- Informer namespace: `informer` → `swarm-informer`
- Worker namespaces: `<mode>-n<i>` → `swarm-<mode>-n<i>` (e.g. `ambient-n1` → `swarm-ambient-n1`, `sidecar-n1` → `swarm-sidecar-n1`)

Updates the embedded `informer-{ambient,sidecar,common}.goyaml` templates, the worker `--informer-url` default, and the Go callers in `swarmctl` that compute namespace names for worker install and telemetry. Also updates the worker command Long description and example help text.

`go build ./...` passes; `swarmctl ... --dry-run` output verified to use the new namespace names.
