### PR TITLE
Add 'swarmctl delete' command

### DIFF
--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -32,7 +32,7 @@ var version = "0.0.0"
 func init() {
 
 	// Add commands
-	rootCmd.AddCommand(dumpCmd, informerCmd, workerCmd)
+	rootCmd.AddCommand(dumpCmd, informerCmd, workerCmd, deleteCmd)
 	informerCmd.AddCommand(informerTelemetryCmd)
 	workerCmd.AddCommand(workerTelemetryCmd)
 
@@ -122,6 +122,19 @@ func init() {
 		// --log-responses flag
 		c.PersistentFlags().Bool("log-responses", false, "If set, the worker logs the raw JSON response bodies received from the informer's /services endpoint and from peer pods' /data endpoint.")
 	}
+
+	//---------------------------
+	// delete flags
+	//---------------------------
+
+	// Registered separately on deleteCmd so they don't leak into the
+	// install/worker subtrees and vice versa.
+	deleteCmd.Flags().String("context", "", "regex to match the context name.")
+	if err := deleteCmd.RegisterFlagCompletionFunc("context", contextCompletion); err != nil {
+		panic(err)
+	}
+	deleteCmd.Flags().Bool("yes", false, "Automatically confirm all prompts with 'yes'.")
+	deleteCmd.Flags().Bool("dry-run", false, "Print what would be deleted without contacting the cluster.")
 }
 
 //-----------------------------------------------------------------------------
@@ -152,6 +165,17 @@ var dumpCmd = &cobra.Command{
 	Aliases:      []string{"d"},
 	Args:         cobra.NoArgs,
 	RunE:         swarmctl.Dump,
+}
+
+var deleteCmd = &cobra.Command{
+	Use:          "delete",
+	Short:        "Deletes everything swarmctl has installed.",
+	SilenceUsage: true,
+	Example:      swarmctl.DeleteExample(),
+	Aliases:      []string{"rm"},
+	Args:         cobra.NoArgs,
+	PreRunE:      validateFlags,
+	RunE:         swarmctl.Delete,
 }
 
 var informerCmd = &cobra.Command{

--- a/cmd/swarmctl/pkg/k8sctx/k8sctx.go
+++ b/cmd/swarmctl/pkg/k8sctx/k8sctx.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	// Community
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -314,4 +315,58 @@ func parseClusterDomainFromCorefile(corefile string) string {
 	domain = strings.TrimSpace(domain)
 
 	return domain
+}
+
+//-----------------------------------------------------------------------------
+// ListByLabel returns the names of objects of the given GVR that carry
+// the supplied label selector. For namespaced resources, namespace=""
+// targets all namespaces.
+//-----------------------------------------------------------------------------
+
+func (c *Context) ListByLabel(ctx context.Context, gvr schema.GroupVersionResource, namespace, labelSelector string) ([]string, error) {
+
+	defer trace.StartRegion(ctx, "ListByLabel").End()
+
+	var ri dynamic.ResourceInterface = c.DynCli.Resource(gvr)
+	if namespace != "" {
+		ri = c.DynCli.Resource(gvr).Namespace(namespace)
+	}
+
+	list, err := ri.List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, fmt.Errorf("listing %s with selector %q: %w", gvr.Resource, labelSelector, err)
+	}
+
+	names := make([]string, 0, len(list.Items))
+	for _, item := range list.Items {
+		names = append(names, item.GetName())
+	}
+	return names, nil
+}
+
+//-----------------------------------------------------------------------------
+// DeleteResource deletes the named object of the given GVR. Missing
+// objects are treated as success (idempotent). If namespace is empty the
+// resource is treated as cluster-scoped.
+//-----------------------------------------------------------------------------
+
+func (c *Context) DeleteResource(ctx context.Context, gvr schema.GroupVersionResource, kind, namespace, name string) error {
+
+	defer trace.StartRegion(ctx, "DeleteResource").End()
+
+	var ri dynamic.ResourceInterface = c.DynCli.Resource(gvr)
+	if namespace != "" {
+		ri = c.DynCli.Resource(gvr).Namespace(namespace)
+	}
+
+	err := ri.Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			fmt.Printf("  - %s/%s not found (skipped)\n", kind, name)
+			return nil
+		}
+		return fmt.Errorf("deleting %s/%s: %w", kind, name, err)
+	}
+	fmt.Printf("  - %s/%s deleted\n", kind, name)
+	return nil
 }

--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -8,6 +8,7 @@ import (
 
 	// Stdlib
 	"bufio"
+	stdctx "context"
 	"embed"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 
 	// Community
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	// Local
 	"github.com/h0tbird/k-swarm/cmd/swarmctl/pkg/k8sctx"
@@ -607,5 +609,216 @@ func InstallWorkerTelemetryExample() string {
 
   # Same using command aliases
   swarmctl w t 1:1 on
+  `
+}
+
+//-----------------------------------------------------------------------------
+// Delete removes everything swarmctl has installed in the matching contexts.
+// Targets are identified by the label app.kubernetes.io/managed-by=swarmctl,
+// which is set by every embedded template:
+//   - cluster-scoped: ClusterRole, ClusterRoleBinding
+//   - namespaced:     Namespace (cascades all child resources)
+//-----------------------------------------------------------------------------
+
+const deleteLabelSelector = "app.kubernetes.io/managed-by=swarmctl"
+
+var (
+	deleteNsGVR         = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+	deleteClusterScoped = []struct {
+		Kind string
+		GVR  schema.GroupVersionResource
+	}{
+		{"ClusterRoleBinding", schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}},
+		{"ClusterRole", schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}},
+	}
+)
+
+// deletePlan captures, for a single context, the swarmctl-managed resources
+// discovered on the cluster.
+type deletePlan struct {
+	ctx        *k8sctx.Context
+	namespaces []string
+	cluster    map[string][]string // kind -> names
+}
+
+func (p *deletePlan) empty() bool {
+	if len(p.namespaces) > 0 {
+		return false
+	}
+	for _, names := range p.cluster {
+		if len(names) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// discoverDeletePlan lists every swarmctl-managed resource in the given context.
+func discoverDeletePlan(ctx stdctx.Context, c *k8sctx.Context) (*deletePlan, error) {
+	p := &deletePlan{ctx: c, cluster: map[string][]string{}}
+
+	nss, err := c.ListByLabel(ctx, deleteNsGVR, "", deleteLabelSelector)
+	if err != nil {
+		return nil, err
+	}
+	p.namespaces = nss
+
+	for _, t := range deleteClusterScoped {
+		names, err := c.ListByLabel(ctx, t.GVR, "", deleteLabelSelector)
+		if err != nil {
+			return nil, err
+		}
+		p.cluster[t.Kind] = names
+	}
+	return p, nil
+}
+
+// printDeletePreview prints the discovered targets for a single context.
+func printDeletePreview(cmd *cobra.Command, name string, p *deletePlan) {
+	cmd.Printf("  - %s\n", name)
+	for _, ns := range p.namespaces {
+		cmd.Printf("      Namespace/%s\n", ns)
+	}
+	for _, t := range deleteClusterScoped {
+		for _, n := range p.cluster[t.Kind] {
+			cmd.Printf("      %s/%s\n", t.Kind, n)
+		}
+	}
+}
+
+// executeDeletePlan deletes cluster-scoped resources first (bindings before
+// roles) then namespaces. Per-resource errors are printed and execution
+// continues, mirroring the ApplyYaml loop in the install commands.
+func executeDeletePlan(ctx stdctx.Context, p *deletePlan) {
+	for _, t := range deleteClusterScoped {
+		for _, n := range p.cluster[t.Kind] {
+			if err := p.ctx.DeleteResource(ctx, t.GVR, t.Kind, "", n); err != nil {
+				fmt.Printf("\nError: %s\n", err)
+			}
+		}
+	}
+	for _, ns := range p.namespaces {
+		if err := p.ctx.DeleteResource(ctx, deleteNsGVR, "Namespace", "", ns); err != nil {
+			fmt.Printf("\nError: %s\n", err)
+		}
+	}
+}
+
+// printDeleteDryRun renders the static deletion plan without contacting any cluster.
+func printDeleteDryRun(cmd *cobra.Command, matches []string) {
+	cmd.Println("\nMatched contexts:")
+	for _, name := range matches {
+		cmd.Printf("  - %s\n", name)
+	}
+	cmd.Printf("\nWould delete in each context (label %q):\n", deleteLabelSelector)
+	for _, t := range deleteClusterScoped {
+		cmd.Printf("  - %s (cluster-scoped)\n", t.Kind)
+	}
+	cmd.Println("  - Namespace (cascades all child resources)")
+}
+
+// confirmDelete prompts the user to confirm a destructive delete.
+func confirmDelete(cmd *cobra.Command) error {
+	cmd.Print("\nProceed with deletion? (y/N) ")
+	reader := bufio.NewReader(os.Stdin)
+	answer, err := util.YesOrNo(cmd, reader)
+	if err != nil {
+		return fmt.Errorf("error reading user input: %w", err)
+	}
+	if answer == "" || answer == "n" || answer == "no" {
+		cmd.SetErrPrefix("aborted:")
+		return errors.New("by user")
+	}
+	return nil
+}
+
+func Delete(cmd *cobra.Command, args []string) error {
+
+	// Get the flags
+	ctxRegex, _ := cmd.Flags().GetString("context")
+	assumeYes, _ := cmd.Flags().GetBool("yes")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+	// Set the error prefix
+	cmd.SetErrPrefix("\nError:")
+
+	// Run the root PersistentPreRunE (profiling, etc.)
+	if err := cmd.Root().PersistentPreRunE(cmd, args); err != nil {
+		return err
+	}
+
+	// Get the contexts that match the regex
+	matches, err := k8sctx.Filter(ctxRegex)
+	if err != nil {
+		return err
+	}
+
+	// Dry-run: print the static plan per matched context, no live client
+	if dryRun {
+		printDeleteDryRun(cmd, matches)
+		return nil
+	}
+
+	// Build live contexts and discover what's actually there
+	plans := make(map[string]*deletePlan, len(matches))
+	cmd.Println("\nMatched contexts:")
+	for _, name := range matches {
+		c, err := k8sctx.New(name)
+		if err != nil {
+			return err
+		}
+		p, err := discoverDeletePlan(cmd.Context(), c)
+		if err != nil {
+			return err
+		}
+		plans[name] = p
+		printDeletePreview(cmd, name, p)
+	}
+
+	// Bail out early if nothing to do
+	nothing := true
+	for _, p := range plans {
+		if !p.empty() {
+			nothing = false
+			break
+		}
+	}
+	if nothing {
+		cmd.Println("\nNothing to delete.")
+		return nil
+	}
+
+	// A chance to cancel
+	if !assumeYes {
+		if err := confirmDelete(cmd); err != nil {
+			return err
+		}
+	}
+
+	// Perform deletes per context
+	for name, p := range plans {
+		fmt.Printf("\n%s\n", name)
+		executeDeletePlan(cmd.Context(), p)
+	}
+
+	return nil
+}
+
+func DeleteExample() string {
+	return `
+  # Delete everything swarmctl has installed in the current context
+  swarmctl delete
+
+  # Same using the command alias
+  swarmctl rm
+
+  # Delete everything in all contexts that match a regex
+  swarmctl delete --context 'kind-pasta-.*'
+
+  # Skip the confirmation prompt
+  swarmctl delete --context 'kind-pasta-.*' --yes
+
+  # Show what would be deleted without contacting the cluster
+  swarmctl delete --context 'kind-pasta-.*' --dry-run
   `
 }


### PR DESCRIPTION
## Summary

Adds a new top-level `swarmctl delete` command (alias `rm`) that removes
everything swarmctl has installed across one or more clusters.

## How targets are identified

Every embedded template (informer + worker, both sidecar and ambient
flavors) sets the label `app.kubernetes.io/managed-by: swarmctl` on the
namespace it creates and on the cluster-scoped RBAC it installs. The
delete command uses that label selector to discover what to remove:

- **Cluster-scoped**: `ClusterRoleBinding` (deleted first, to release
  references), then `ClusterRole`.
- **Namespaced**: `Namespace` — deletion cascades to every child
  resource swarmctl installed (Service, Deployment, ServiceAccount,
  Role/RoleBinding, Gateway, VirtualService, HTTPRoute, DestinationRule,
  PeerAuthentication, AuthorizationPolicy, Telemetry, …).

This is symmetric with the install commands and avoids hardcoding
namespace names or kinds.

## Flags

- \`--context\` (regex) — same semantics as \`swarmctl informer\` /
  \`swarmctl worker\`. Empty means \"current context\".
- \`--yes\` — skip the y/N confirmation.
- \`--dry-run\` — print the deletion plan without contacting any cluster.

The command does **not** accept \`--dataplane-mode\` or per-component
subcommands; it intentionally nukes everything swarmctl owns.

## UX

Without \`--dry-run\`, the command discovers the actual resources first
and prints a per-context preview before prompting:

```
Matched contexts:
  - kind-pasta-1
      Namespace/informer
      Namespace/sidecar-n1
      ClusterRoleBinding/k-swarm-informer-manager-rolebinding
      ClusterRole/k-swarm-informer-manager-role
      ClusterRole/k-swarm-informer-metrics-reader

Proceed with deletion? (y/N)
```

Re-runs are idempotent: missing objects are reported as
\`<Kind>/<name> not found (skipped)\`.

## Implementation

- \`pkg/k8sctx\`: two new helpers — \`ListByLabel\` and \`DeleteResource\`
  (treats \`NotFound\` as success).
- \`pkg/swarmctl\`: \`Delete\` orchestrator + small helpers
  (\`discoverDeletePlan\`, \`printDeletePreview\`, \`executeDeletePlan\`,
  \`printDeleteDryRun\`, \`confirmDelete\`) to keep cyclomatic complexity
  in check.
- \`cmd/cmd.go\`: register \`deleteCmd\` and its three flags directly on
  the command (so they don't pollute the install/worker subtrees, same
  pattern already used there).

## Verification

- \`go build ./... && go vet ./... && bin/golangci-lint run ./cmd/...\`
  — all clean.
- \`go test ./...\` — existing tests pass; no new tests added (this
  command has no unit-testable pure logic; everything either lists or
  deletes against a live cluster).
- \`swarmctl --help\` and \`swarmctl delete --help\` render correctly.