### PR TITLE
feat(swarmctl): support --multi-cluster for sidecar dataplane mode

### DIFF
--- a/cmd/swarmctl/assets/worker-sidecar.goyaml
+++ b/cmd/swarmctl/assets/worker-sidecar.goyaml
@@ -21,6 +21,12 @@ metadata:
     app.kubernetes.io/managed-by: swarmctl
     app.kubernetes.io/name: peer
     app.kubernetes.io/part-of: k-swarm
+    {{- if .MultiCluster }}
+    # Required by the mesh's serviceScopeConfigs filter so this Service
+    # is exported across clusters and istiod publishes its endpoints in
+    # remote sidecar EDS via the cross-network gateway on 15443.
+    istio.io/global: "true"
+    {{- end }}
   name: peer
   namespace: {{ .Namespace }}
 spec:
@@ -152,7 +158,15 @@ spec:
     loadBalancer:
       simple: LEAST_REQUEST
       localityLbSetting:
+        {{- if .MultiCluster }}
+        # Disable locality load balancing to force failover across clusters
+        # so cross-cluster sidecar->sidecar requests are exercised.
+        enabled: false
+        failoverPriority:
+          - topology.istio.io/cluster
+        {{- else }}
         enabled: true
+        {{- end }}
     outlierDetection:
       consecutive5xxErrors: 1
       interval: 1s

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -117,7 +117,7 @@ func init() {
 		c.PersistentFlags().Bool("dry-run", false, "Render manifests to stdout without applying them or contacting the cluster.")
 
 		// --multi-cluster flag
-		c.PersistentFlags().Bool("multi-cluster", false, "Enable cross-cluster failover for ambient mode: labels the peer and waypoint Services with istio.io/global=true and emits a DestinationRule with locality failover by topology.istio.io/cluster.")
+		c.PersistentFlags().Bool("multi-cluster", false, "Enable cross-cluster failover: labels the peer Service (and ambient waypoint Service) with istio.io/global=true and emits a DestinationRule with locality failover by topology.istio.io/cluster. Works for both ambient and sidecar dataplane modes.")
 
 		// --log-responses flag
 		c.PersistentFlags().Bool("log-responses", false, "If set, the worker logs the raw JSON response bodies received from the informer's /services endpoint and from peer pods' /data endpoint.")

--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -510,10 +510,12 @@ func InstallWorkerExample() string {
   # Expose the peer Service via a dedicated Gateway API Gateway+HTTPRoute.
   swarmctl w 1:1 --dataplane-mode ambient --context 'kind-pasta-.*' --ingress-mode dedicated
 
-  # Enable cross-cluster failover for ambient-mode workers: labels the peer
-  # and waypoint Services with istio.io/global=true and emits a DestinationRule
-  # with locality failover by topology.istio.io/cluster (ambient-only).
-  swarmctl w 1:1 --dataplane-mode ambient --context 'kind-pasta-.*' --multi-cluster
+  # Enable cross-cluster failover: labels the peer Service (and ambient
+  # waypoint Service) with istio.io/global=true and emits a DestinationRule
+  # with locality failover by topology.istio.io/cluster. Works for both
+  # ambient and sidecar dataplane modes.
+  swarmctl w 1:1 --dataplane-mode ambient  --context 'kind-pasta-.*' --multi-cluster
+  swarmctl w 1:1 --dataplane-mode sidecar --context 'kind-pasta-.*' --multi-cluster
 
   # Render the worker manifests to stdout without applying them or contacting the cluster.
   swarmctl w 1:1 --dataplane-mode ambient --dry-run | kubectl diff -f -

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,7 @@ Key persistent flags shared by `informer` and `worker` (and inherited by their
 | `--node-selector` | _empty_ | Inline YAML node selector for the Deployment pod spec. |
 | `--waypoint-name` | `waypoint` | Name of the per-namespace ambient waypoint Gateway. |
 | `--ingress-mode` | `none` | `none`, `shared` (Istio `Gateway`/`VirtualService` selecting `istio: nsgw`) or `dedicated` (per-namespace Gateway API `Gateway`/`HTTPRoute`). |
-| `--multi-cluster` | `false` | Ambient-only: labels peer and waypoint Services with `istio.io/global=true` and emits a `DestinationRule` with locality failover by `topology.istio.io/cluster`. |
+| `--multi-cluster` | `false` | Labels the peer Service (and ambient waypoint Service) with `istio.io/global=true` and emits a `DestinationRule` with locality failover by `topology.istio.io/cluster`. Works for both ambient and sidecar dataplane modes. |
 | `--log-responses` | `false` | Renders the worker manifest with `--worker-log-responses`, causing each pod to log raw JSON bodies received from the informer and peers. |
 | `--dry-run` | `false` | Render YAML to stdout; skip cluster discovery and apply. |
 | `--yes` | `false` | Skip the confirmation prompt before applying. |
@@ -188,8 +188,14 @@ namespace it can emit, depending on flags:
   `Gateway` (`gatewayClassName: istio-waypoint`); the peer Service is
   labeled `istio.io/use-waypoint`.
 - Ambient + `--multi-cluster`: peer and waypoint Services are labeled
-  `istio.io/global=true` and an extra `DestinationRule` with locality
-  failover by `topology.istio.io/cluster` is emitted.
+  `istio.io/global=true` and the `DestinationRule` carries locality
+  failover by `topology.istio.io/cluster`.
+- Sidecar + `--multi-cluster`: peer Service is labeled
+  `istio.io/global=true` and the `DestinationRule` switches to disabled
+  locality LB with failover by `topology.istio.io/cluster` so that
+  cross-cluster sidecar->sidecar traffic is exercised. Requires a
+  cross-network east-west gateway with a TLS Passthrough listener on
+  port 15443 in the mesh.
 - `--ingress-mode shared`: an Istio `Gateway`/`VirtualService` pair selecting
   the shared `istio: nsgw` workload.
 - `--ingress-mode dedicated`: a Gateway API `Gateway`/`HTTPRoute` pair with


### PR DESCRIPTION
## Problem

`--multi-cluster` previously only affected the **ambient** worker render.
For sidecar workers it was a no-op, so the rendered `peer` Service had
no `istio.io/global=true` label and the `DestinationRule` kept locality
load balancing enabled without any cross-cluster failover.

In meshes that use Istio's `serviceScopeConfigs` to scope which Services
are exported across clusters (e.g. the meshlab install), the missing
label means istiod never publishes sidecar `peer` Services to remote
clusters. Even after a properly configured cross-network east-west
gateway with TLS Passthrough on 15443 is in place, sidecar EDS in a
remote cluster contains only local endpoints and sidecar->sidecar
cross-cluster traffic fails.

## Change

Mirror the ambient behavior in the sidecar template and broaden the
flag's documented scope:

* [`cmd/swarmctl/assets/worker-sidecar.goyaml`](k-swarm/cmd/swarmctl/assets/worker-sidecar.goyaml)
  * Gate `istio.io/global: "true"` on the peer Service behind
    `.MultiCluster`.
  * When `.MultiCluster` is set, switch the `DestinationRule`'s
    `localityLbSetting` to `enabled: false` with
    `failoverPriority: [topology.istio.io/cluster]`, matching the
    ambient behavior so cross-cluster sidecar->sidecar requests are
    actually exercised.
* [`cmd/swarmctl/cmd/cmd.go`](k-swarm/cmd/swarmctl/cmd/cmd.go) — widen
  `--multi-cluster` help text from "Ambient-only" to cover both data
  plane modes.
* [`cmd/swarmctl/pkg/swarmctl/swarmctl.go`](k-swarm/cmd/swarmctl/pkg/swarmctl/swarmctl.go) —
  update the help example accordingly.
* [`docs/architecture.md`](k-swarm/docs/architecture.md) — update the
  flag table row and the per-mode emit list to mention sidecar +
  `--multi-cluster`.

## Validation

`swarmctl w 1:1 --dataplane-mode sidecar --multi-cluster --dry-run`:

```yaml
kind: Service
metadata:
  labels:
    istio.io/global: "true"   # new
...
kind: DestinationRule
spec:
  trafficPolicy:
    loadBalancer:
      localityLbSetting:
        enabled: false                                    # was: true
        failoverPriority:                                 # new
          - topology.istio.io/cluster
```

Without `--multi-cluster` the rendered manifests are unchanged from
before this PR (label absent, locality LB enabled).

## Notes

* This change is the workload-side counterpart to the meshlab PRs that
  add the sidecar east-west gateway and enable `PILOT_ENABLE_ALPHA_GATEWAY_API`
  (h0tbird/meshlab#44, h0tbird/meshlab#45, h0tbird/meshlab#46). With all
  four merged the sidecar↔* cross-cluster cells of the connectivity
  matrix should turn green.
