### PR TITLE
fix(worker): avoid CPU busy loop and remove serviceList data race

### DIFF
--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	// Community
@@ -26,7 +27,10 @@ import (
 //-----------------------------------------------------------------------------
 
 var (
-	serviceList = []string{}
+	// serviceList is updated by pollServiceList and read by client. Using an
+	// atomic.Pointer makes the swap and load race-free without a mutex;
+	// readers always observe a fully-published slice header.
+	serviceList atomic.Pointer[[]string]
 	log         = ctrl.Log.WithName("peer")
 )
 
@@ -112,7 +116,7 @@ func client(ctx context.Context, flags *common.FlagPack) {
 	log := log.WithValues("src", localPeer())
 
 	// Get the service list from the informer
-	go pollServiceList(ctx, flags, &serviceList)
+	go pollServiceList(ctx, flags)
 
 	// Pace requests with a ticker so an empty service list (e.g. before the
 	// informer has responded for the first time) does not turn the outer loop
@@ -127,7 +131,11 @@ func client(ctx context.Context, flags *common.FlagPack) {
 			log.Info("client context done")
 			return
 		case <-ticker.C:
-			for _, service := range serviceList {
+			services := serviceList.Load()
+			if services == nil {
+				continue
+			}
+			for _, service := range *services {
 				start := time.Now()
 				resp, err := http.Get(fmt.Sprintf("http://%s/data", service))
 				if err != nil {
@@ -193,7 +201,7 @@ type httpInfo struct {
 // pollServiceList polls the service list from the informer
 //-----------------------------------------------------------------------------
 
-func pollServiceList(ctx context.Context, flags *common.FlagPack, serviceList *[]string) {
+func pollServiceList(ctx context.Context, flags *common.FlagPack) {
 
 	// Setup a ticker
 	ticker := time.NewTicker(flags.InformerPollInterval)
@@ -209,7 +217,7 @@ func pollServiceList(ctx context.Context, flags *common.FlagPack, serviceList *[
 				log.Error(err, "failed to fetch services")
 				continue
 			}
-			*serviceList = newServices
+			serviceList.Store(&newServices)
 		case <-ctx.Done():
 			log.Info("client context done")
 			return

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -114,15 +114,20 @@ func client(ctx context.Context, flags *common.FlagPack) {
 	// Get the service list from the informer
 	go pollServiceList(ctx, flags, &serviceList)
 
+	// Pace requests with a ticker so an empty service list (e.g. before the
+	// informer has responded for the first time) does not turn the outer loop
+	// into a busy spin pegging a CPU core.
+	ticker := time.NewTicker(flags.WorkerRequestInterval)
+	defer ticker.Stop()
+
 	// Loop over the service list and make requests to /data
 	for {
 		select {
 		case <-ctx.Done():
 			log.Info("client context done")
 			return
-		default:
+		case <-ticker.C:
 			for _, service := range serviceList {
-				time.Sleep(flags.WorkerRequestInterval)
 				start := time.Now()
 				resp, err := http.Get(fmt.Sprintf("http://%s/data", service))
 				if err != nil {


### PR DESCRIPTION
## Problem 1 — CPU busy loop on startup

When worker pods start, they exhibit a period of very high CPU usage until the informer responds with the service list for the first time.

The cause is in `client()` in `pkg/worker/worker.go`:

```go
for {
    select {
    case <-ctx.Done():
        return
    default:
        for _, service := range serviceList {
            time.Sleep(flags.WorkerRequestInterval)
            ...
        }
    }
}
```

The `time.Sleep` lives inside the inner `range serviceList`. While `serviceList` is empty (the initial state, before the informer has populated it), the inner loop iterates zero times and nothing ever sleeps. The outer `for { select { default: ... } }` then becomes a tight busy loop that pegs a CPU core. As soon as the informer returns a non-empty list, the inner sleep kicks in and CPU drops back to normal — which matches the observed symptom.

### Fix

Drive the outer loop with a `time.Ticker` at `WorkerRequestInterval` instead of a `default` branch with an inner sleep. This guarantees the goroutine parks on a channel each iteration, regardless of whether `serviceList` is populated. As a small bonus, `ctx.Done()` is now checked on every tick rather than only between full passes over the service list, so shutdown is more responsive.

## Problem 2 — `serviceList` data race

`serviceList` was a package-level `[]string` written by `pollServiceList` (via a `*[]string` parameter) and concurrently read by `client`'s `range` loop, with no synchronization. A `[]string` is a 3-word slice header (data pointer, length, capacity), so this access:

- is a data race per the Go memory model (`go test -race` would flag it),
- is vulnerable to torn reads (e.g. new pointer with stale length), and
- gives no happens-before guarantee that the reader ever observes the writer's update.

### Fix

Replace the shared slice with `atomic.Pointer[[]string]`:

- `pollServiceList` calls `serviceList.Store(&newServices)`.
- `client` calls `serviceList.Load()` each tick; a `nil` pointer (no informer response yet) just skips that iteration.

No mutex needed and readers always observe a fully-published slice header.

## Validation

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race ./pkg/worker/...` — no test files in this package, but the binary builds race-free