### PR TITLE
feat(worker): add --disable-keepalives to spread traffic across endpoints

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -140,6 +140,15 @@ func initFlags(fs *pflag.FlagSet) *common.FlagPack {
 		false,
 		"If set, log the raw JSON response bodies received from the informer's /services endpoint and from peer workers' /data endpoint.")
 
+	fs.BoolVar(
+		&flags.WorkerDisableKeepAlives,
+		"worker-disable-keepalives",
+		false,
+		"If set, the worker opens a new TCP connection for every request instead of reusing HTTP keep-alive connections. "+
+			"L4 proxies such as ztunnel load balance per connection, so a reused connection pins every request to a single "+
+			"endpoint. Disabling keep-alives re-runs endpoint selection on every request, which spreads traffic across all "+
+			"endpoints (including remote clusters) at the cost of a connection setup per request.")
+
 	return flags
 }
 

--- a/cmd/swarmctl/assets/worker-ambient.goyaml
+++ b/cmd/swarmctl/assets/worker-ambient.goyaml
@@ -71,6 +71,9 @@ spec:
         {{- if .LogResponses }}
         - --worker-log-responses
         {{- end }}
+        {{- if .DisableKeepAlives }}
+        - --worker-disable-keepalives
+        {{- end }}
         command:
         - /manager
         env:

--- a/cmd/swarmctl/assets/worker-sidecar.goyaml
+++ b/cmd/swarmctl/assets/worker-sidecar.goyaml
@@ -77,6 +77,9 @@ spec:
         {{- if .LogResponses }}
         - --worker-log-responses
         {{- end }}
+        {{- if .DisableKeepAlives }}
+        - --worker-disable-keepalives
+        {{- end }}
         command:
         - /manager
         env:

--- a/cmd/swarmctl/cmd/cmd.go
+++ b/cmd/swarmctl/cmd/cmd.go
@@ -121,6 +121,9 @@ func init() {
 
 		// --log-responses flag
 		c.PersistentFlags().Bool("log-responses", false, "If set, the worker logs the raw JSON response bodies received from the informer's /services endpoint and from peer pods' /data endpoint.")
+
+		// --disable-keepalives flag
+		c.PersistentFlags().Bool("disable-keepalives", false, "If set, the worker opens a new TCP connection per request instead of reusing HTTP keep-alive connections. L4 proxies such as ztunnel load balance per connection, so a reused connection pins every request to one endpoint; disabling keep-alives spreads traffic across all endpoints, including remote clusters.")
 	}
 
 	//---------------------------

--- a/cmd/swarmctl/pkg/swarmctl/swarmctl.go
+++ b/cmd/swarmctl/pkg/swarmctl/swarmctl.go
@@ -375,6 +375,7 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 	ingressMode, _ := cmd.Flags().GetString("ingress-mode")
 	multiCluster, _ := cmd.Flags().GetBool("multi-cluster")
 	logResponses, _ := cmd.Flags().GetBool("log-responses")
+	disableKeepAlives, _ := cmd.Flags().GetBool("disable-keepalives")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 
 	// Set the error prefix
@@ -426,33 +427,35 @@ func InstallWorker(cmd *cobra.Command, args []string) error {
 
 			// Render the template
 			docs, err := util.RenderTemplate(tmpl, struct {
-				Replicas      int
-				Namespace     string
-				NodeSelector  string
-				Version       string
-				ImageTag      string
-				IstioRevision string
-				ClusterDomain string
-				ClusterName   string
-				DataplaneMode string
-				WaypointName  string
-				IngressMode   string
-				MultiCluster  bool
-				LogResponses  bool
+				Replicas          int
+				Namespace         string
+				NodeSelector      string
+				Version           string
+				ImageTag          string
+				IstioRevision     string
+				ClusterDomain     string
+				ClusterName       string
+				DataplaneMode     string
+				WaypointName      string
+				IngressMode       string
+				MultiCluster      bool
+				LogResponses      bool
+				DisableKeepAlives bool
 			}{
-				Replicas:      replicas,
-				Namespace:     namespace,
-				NodeSelector:  nodeSelector,
-				Version:       cmd.Root().Version,
-				ImageTag:      imageTag,
-				IstioRevision: istioRevision,
-				ClusterDomain: clusterDomain,
-				ClusterName:   clusterName,
-				DataplaneMode: dataplaneMode,
-				WaypointName:  waypointName,
-				IngressMode:   ingressMode,
-				MultiCluster:  multiCluster,
-				LogResponses:  logResponses,
+				Replicas:          replicas,
+				Namespace:         namespace,
+				NodeSelector:      nodeSelector,
+				Version:           cmd.Root().Version,
+				ImageTag:          imageTag,
+				IstioRevision:     istioRevision,
+				ClusterDomain:     clusterDomain,
+				ClusterName:       clusterName,
+				DataplaneMode:     dataplaneMode,
+				WaypointName:      waypointName,
+				IngressMode:       ingressMode,
+				MultiCluster:      multiCluster,
+				LogResponses:      logResponses,
+				DisableKeepAlives: disableKeepAlives,
 			})
 			if err != nil {
 				return err

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -21,10 +21,11 @@ type FlagPack struct {
 	InformerBindAddr string
 
 	// Worker flags
-	EnableWorker          bool
-	WorkerBindAddr        string
-	InformerPollInterval  time.Duration
-	WorkerRequestInterval time.Duration
-	InformerURL           string
-	WorkerLogResponses    bool
+	EnableWorker            bool
+	WorkerBindAddr          string
+	InformerPollInterval    time.Duration
+	WorkerRequestInterval   time.Duration
+	InformerURL             string
+	WorkerLogResponses      bool
+	WorkerDisableKeepAlives bool
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -115,6 +115,17 @@ func client(ctx context.Context, flags *common.FlagPack) {
 	// self-describing as "src -> dst" when tailing logs from many pods.
 	log := log.WithValues("src", localPeer())
 
+	// L4 proxies (ztunnel) select an upstream endpoint once per TCP
+	// connection, so the default keep-alive pooling pins every request from
+	// this pod to whichever endpoint the first connection landed on. Opening a
+	// fresh connection per request re-runs that selection every time, which is
+	// what makes traffic actually spread over all endpoints of a service.
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DisableKeepAlives: flags.WorkerDisableKeepAlives,
+		},
+	}
+
 	// Get the service list from the informer
 	go pollServiceList(ctx, flags)
 
@@ -137,7 +148,7 @@ func client(ctx context.Context, flags *common.FlagPack) {
 			}
 			for _, service := range *services {
 				start := time.Now()
-				resp, err := http.Get(fmt.Sprintf("http://%s/data", service))
+				resp, err := httpClient.Get(fmt.Sprintf("http://%s/data", service))
 				if err != nil {
 					log.Error(err, "request failed", "service", service)
 					continue


### PR DESCRIPTION
## Problem

The worker client used `http.Get`, i.e. `http.DefaultClient`, which pools HTTP keep-alive connections.

`ztunnel` is an L4 proxy: it selects an upstream endpoint **once per TCP connection**, not per HTTP request. So a reused keep-alive connection pins every subsequent request to whichever endpoint the first connection happened to land on. In a multi-cluster ambient mesh this makes each peer talk to exactly **one cluster per service** for its entire lifetime — even though every endpoint is discovered and healthy.

This showed up in the meshlab `pasta` cell connectivity matrix: sidecar sources were all-green (Envoy is L7 and re-balances per request), while every ambient source reached only one cluster per destination service. It looked like a connectivity failure but was purely a load-balancing artifact.

## Evidence

From an ambient pod, 20 requests to the same service:

| | `peer.swarm-ambient-n2` | `peer.swarm-sidecar-n1` |
|---|---|---|
| new connection per request | 16x pasta-1, 4x pasta-2 | 9x pasta-1, 11x pasta-2 |
| one reused keep-alive connection | **20x pasta-2** | **20x pasta-2** |

A destination waypoint does *not* rescue this — the waypointed service is still fully pinned on a reused connection.

## Change

- Give the worker its own `http.Client` instead of `http.DefaultClient`, with `Transport.DisableKeepAlives` wired to a new flag.
- New manager flag `--worker-disable-keepalives`.
- Surfaced on swarmctl as `--disable-keepalives`, rendered into both the ambient and sidecar worker manifests.

Default stays `false`, so current behaviour is unchanged unless the flag is set.

## Testing

- `go build ./...` and `go vet ./...` clean.
- Rendered manifests via `--dry-run` for both dataplane modes, with and without the flag, confirming the arg is emitted only when requested.
- Mechanism verified live in the meshlab pasta cell with the curl experiment above.

> [!NOTE]
> Not yet verified end-to-end in-cluster: the peer Deployment pins `ghcr.io/h0tbird/k-swarm:main` with `imagePullPolicy: Always`, so a locally built image can't be side-loaded. Needs CI to publish `:main` after merge.

Companion change in meshlab passes `--disable-keepalives` from `bin/meshlab` `deploy-workloads`; merge and publish this one first.
